### PR TITLE
Compose: keep containers grouped on recreate + remember group expansion

### DIFF
--- a/ContainerGUI/Features/Containers/ContainerStore.swift
+++ b/ContainerGUI/Features/Containers/ContainerStore.swift
@@ -9,6 +9,22 @@ final class ContainerStore {
     var error: CLIError?
     var pendingIDs: Set<String> = []
 
+    /// Compose project names the user has collapsed in the list. Absent = expanded
+    /// (Docker-Desktop-like default). Held on the store so the expand/collapse state
+    /// survives `ContainersView` being recreated on sidebar navigation, and persisted
+    /// across launches.
+    var collapsedProjects: Set<String> = ContainerStore.loadCollapsed() {
+        didSet { ContainerStore.saveCollapsed(collapsedProjects) }
+    }
+
+    private static let collapsedKey = "collapsedComposeProjects"
+    private static func loadCollapsed() -> Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: collapsedKey) ?? [])
+    }
+    private static func saveCollapsed(_ value: Set<String>) {
+        UserDefaults.standard.set(Array(value), forKey: collapsedKey)
+    }
+
     private let cli = ContainerCLI.shared
 
     var runningCount: Int { items.filter(\.isRunning).count }

--- a/ContainerGUI/Features/Containers/ContainersView.swift
+++ b/ContainerGUI/Features/Containers/ContainersView.swift
@@ -33,6 +33,22 @@ struct ContainersView: View {
 
     private var store: ContainerStore { model.containers }
 
+    /// Expand/collapse binding for a Compose project group, backed by the store
+    /// (so it survives this view being recreated on sidebar navigation). Default
+    /// is expanded; collapsing is remembered.
+    private func expansion(for project: String) -> Binding<Bool> {
+        Binding(
+            get: { !store.collapsedProjects.contains(project) },
+            set: { expanded in
+                if expanded {
+                    store.collapsedProjects.remove(project)
+                } else {
+                    store.collapsedProjects.insert(project)
+                }
+            }
+        )
+    }
+
     private var selectedContainer: ContainerInfo? {
         guard let sel = selection else { return nil }
         // Flat search across all items
@@ -261,7 +277,7 @@ struct ContainersView: View {
             } rows: {
                 ForEach(rows) { row in
                     if let children = row.children {
-                        DisclosureTableRow(row) {
+                        DisclosureTableRow(row, isExpanded: expansion(for: row.projectName ?? row.id)) {
                             ForEach(children) { child in
                                 TableRow(child)
                             }

--- a/ContainerGUI/Features/Containers/RunContainerSheet.swift
+++ b/ContainerGUI/Features/Containers/RunContainerSheet.swift
@@ -104,6 +104,24 @@ struct RunContainerSheet: View {
             initial.workdir = wd
         }
 
+        // Labels — preserve Compose grouping (compose.project / compose.service)
+        // and any other metadata, so an edited container stays in its project.
+        if let labels = cfg.labels {
+            initial.labels = labels
+                .sorted { $0.key < $1.key }
+                .map { RunConfiguration.KeyValue(key: $0.key, value: $0.value) }
+        }
+
+        // Network — keep the container on its (project) network.
+        if let net = cfg.networks?.first?.network, !net.isEmpty {
+            initial.network = net
+        }
+
+        // Architecture — preserve (e.g. amd64 containers running under Rosetta).
+        if let arch = cfg.platform?.architecture, !arch.isEmpty {
+            initial.arch = arch
+        }
+
         _config = State(initialValue: initial)
         replacesContainerID = container.id
     }

--- a/ContainerGUI/Models/ContainerInfo.swift
+++ b/ContainerGUI/Models/ContainerInfo.swift
@@ -32,6 +32,11 @@ struct ContainerInfo: Codable, Identifiable, Sendable, Hashable {
         let readOnly: Bool?
         let ssh: Bool?
         let virtualization: Bool?
+        let networks: [NetworkRef]?
+
+        struct NetworkRef: Codable, Sendable, Hashable {
+            let network: String?
+        }
 
         struct ImageRef: Codable, Sendable, Hashable {
             let reference: String


### PR DESCRIPTION
Two Docker-Compose UX fixes reported locally.

### 1. Editing a container no longer drops it from its Compose project
`RunContainerSheet.init(recreating:)` prefilled image/name/command/env/ports/volumes/resources/rosetta/workdir but **not labels**, so the recreated container lost `compose.project` / `compose.service` and fell out of its group. It now also copies:
- **labels** (Compose grouping + any other metadata),
- **network** (so it stays on the project network) — added `networks` to `ContainerInfo.Configuration` to read it,
- **architecture** (amd64/Rosetta containers).

`RunCommandBuilder` already emits `--label` / `--network` / `--arch`, so filling those fields is enough.

### 2. Compose group expand/collapse is remembered
Groups were rendered with `DisclosureTableRow` with no `isExpanded` binding; their state lived only inside SwiftUI and was lost because `ContainersView` is recreated whenever the sidebar selection changes. Expansion now lives on `ContainerStore` (`collapsedProjects`, persisted to `UserDefaults`) and is bound into each `DisclosureTableRow`. Groups **default to expanded** (Docker-Desktop-like); collapses are remembered across navigation and app launches.

## Verification
- `xcodebuild build` → **BUILD SUCCEEDED**; `xcodebuild test` → **64 tests, 0 failures**.
- Runtime: created a labelled `demo` project (web + db) → renders as an expanded group with a `2/2 running` header; UI confirmed. Recreate label/network/arch preservation verified in code + the builder emitting the flags (final click-through best confirmed locally via *Change configuration…*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)