### PR TITLE
Terminal: Ghostty (libghostty) as an opt-in second engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,16 @@ SwiftUI views (Features/<X>/) → @Observable stores → ContainerCLI (actor) �
 - `CLI/ContainerCLI.swift` — the only place that runs the binary (`json`, `run`, `run(input:)` for stdin, `runElevated` for admin, `stream` for `logs -f`/`stats`). `BinaryResolver` finds the binary (GUI apps don't inherit shell PATH). `RunCommandBuilder` maps a `RunConfiguration` to `container run` args (emits `--label`, `--network`, `--arch`, `--publish`, `--env`, `--volume`, …).
 - `Models/` — `Codable` structs mirroring real CLI JSON; keys verified against live output. `Configuration` includes `labels`, `networks`, `platform`, etc.
 - `Features/<Containers|Images|Volumes|Networks|Registries|Machines|System>/` — store + views per section. `Compose/` translates `docker-compose.yml` to `container run` calls (labels `compose.project` / `compose.service` drive grouping).
-- Deps (SPM in `project.yml`): `SwiftTerm`, `Yams`, `Sparkle`.
+- Deps (SPM in `project.yml`): `SwiftTerm`, `Yams`, `Sparkle`, `libghostty-spm`.
+
+### Terminal engines
+
+`Terminal/` holds two engines behind `@AppStorage("terminalEngine")` (`TerminalEngine`, default `swiftTerm`):
+
+- **SwiftTerm** — CoreText, spawns the PTY itself. The default.
+- **Ghostty (libghostty)** — Metal rendering. `GhosttyTerminalView` hands `container exec -it <id> sh` to libghostty's `.exec` backend as a ghostty `command` config line; libghostty owns the PTY, resizing and the exit report. Opt-in because **libghostty's embedding API is explicitly not stabilized** ("used primarily by the macOS app, may change significantly between releases") and Ghostty publishes only `ghostty-vt` officially — the full library comes from a third-party build, so the package is pinned with `exactVersion`, never `from:`.
+
+Two things that will bite when touching this: libghostty runs the command through `login -flp <user> /bin/bash --noprofile --norc -c exec -l <cmd>`, so (a) the command must stay a plain executable + arguments — a bare `clear; …` gets torn apart, hence the `/bin/sh -c "clear; exec …"` wrapper in `TerminalCommandLine`, and (b) without that `clear` the host's "Last login: … on ttysNNN" shows up above the container's prompt. The XCFramework is a **static** library, so nothing extra needs signing.
 
 ## Localization (important)
 

--- a/ContainerGUI/App/SettingsView.swift
+++ b/ContainerGUI/App/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @Environment(AppModel.self) private var model
     @State private var binaryPath = BinaryResolver.overridePath ?? ""
     @AppStorage("appLanguageOverride") private var languageOverride = "system"
+    @AppStorage(TerminalEngine.storageKey) private var terminalEngine = TerminalEngine.default.rawValue
     @State private var showRelaunchNote = false
 
     var body: some View {
@@ -65,6 +66,25 @@ struct SettingsView: View {
                     Image(systemName: "terminal.fill")
                         .foregroundStyle(Color.blue.gradient)
                     Text("Narzędzie container")
+                }
+            }
+
+            Section {
+                Picker(selection: $terminalEngine) {
+                    ForEach(TerminalEngine.allCases) { engine in
+                        Text(engine.title).tag(engine.rawValue)
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Text("Silnik terminala")
+                        InfoTip(text: String(localized: "Ghostty rysuje przez Metal — ostrzejszy tekst, ligatury i emoji. Jego API do wbudowywania nie jest jeszcze ustabilizowane, dlatego domyślny pozostaje SwiftTerm. Zmiana dotyczy nowo otwieranych terminali."))
+                    }
+                }
+            } header: {
+                HStack(spacing: 5) {
+                    Image(systemName: "apple.terminal.fill")
+                        .foregroundStyle(Color.teal.gradient)
+                    Text("Terminal")
                 }
             }
 

--- a/ContainerGUI/Resources/en.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/en.lproj/Localizable.strings
@@ -489,3 +489,11 @@
 "ostatnie %d" = "last %d";
 "wszystko" = "everything";
 "Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę." = "How much history to fetch. A full log can be very large — loading and drawing it will take a moment.";
+/* Terminal/TerminalEngine.swift — engine switch and shell exit */
+"Silnik terminala" = "Terminal engine";
+"Wbudowany (SwiftTerm)" = "Built-in (SwiftTerm)";
+"Ghostty — Metal (eksperymentalny)" = "Ghostty — Metal (experimental)";
+"Ghostty rysuje przez Metal — ostrzejszy tekst, ligatury i emoji. Jego API do wbudowywania nie jest jeszcze ustabilizowane, dlatego domyślny pozostaje SwiftTerm. Zmiana dotyczy nowo otwieranych terminali." = "Ghostty renders with Metal — sharper text, ligatures and emoji. Its embedding API is not stabilized yet, so SwiftTerm stays the default. The change applies to terminals opened from now on.";
+"Powłoka zakończona." = "Shell exited.";
+"Powłoka zakończona (kod %d)." = "Shell exited (code %d).";
+"Połącz ponownie" = "Reconnect";

--- a/ContainerGUI/Resources/pl.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/pl.lproj/Localizable.strings
@@ -489,3 +489,11 @@
 "ostatnie %d" = "ostatnie %d";
 "wszystko" = "wszystko";
 "Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę." = "Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę.";
+/* Terminal/TerminalEngine.swift — engine switch and shell exit */
+"Silnik terminala" = "Silnik terminala";
+"Wbudowany (SwiftTerm)" = "Wbudowany (SwiftTerm)";
+"Ghostty — Metal (eksperymentalny)" = "Ghostty — Metal (eksperymentalny)";
+"Ghostty rysuje przez Metal — ostrzejszy tekst, ligatury i emoji. Jego API do wbudowywania nie jest jeszcze ustabilizowane, dlatego domyślny pozostaje SwiftTerm. Zmiana dotyczy nowo otwieranych terminali." = "Ghostty rysuje przez Metal — ostrzejszy tekst, ligatury i emoji. Jego API do wbudowywania nie jest jeszcze ustabilizowane, dlatego domyślny pozostaje SwiftTerm. Zmiana dotyczy nowo otwieranych terminali.";
+"Powłoka zakończona." = "Powłoka zakończona.";
+"Powłoka zakończona (kod %d)." = "Powłoka zakończona (kod %d).";
+"Połącz ponownie" = "Połącz ponownie";

--- a/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -489,3 +489,11 @@
 "ostatnie %d" = "最后 %d 行";
 "wszystko" = "全部";
 "Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę." = "获取多少历史记录。完整日志可能非常大 —— 加载和绘制会需要一些时间。";
+/* Terminal/TerminalEngine.swift — engine switch and shell exit */
+"Silnik terminala" = "终端引擎";
+"Wbudowany (SwiftTerm)" = "内置 (SwiftTerm)";
+"Ghostty — Metal (eksperymentalny)" = "Ghostty — Metal（实验性）";
+"Ghostty rysuje przez Metal — ostrzejszy tekst, ligatury i emoji. Jego API do wbudowywania nie jest jeszcze ustabilizowane, dlatego domyślny pozostaje SwiftTerm. Zmiana dotyczy nowo otwieranych terminali." = "Ghostty 使用 Metal 渲染 —— 文字更锐利，支持连字和更好的 emoji。它的嵌入 API 尚未稳定，因此默认仍为 SwiftTerm。该更改只影响此后新打开的终端。";
+"Powłoka zakończona." = "Shell 已退出。";
+"Powłoka zakończona (kod %d)." = "Shell 已退出（退出码 %d）。";
+"Połącz ponownie" = "重新连接";

--- a/ContainerGUI/Terminal/EmbeddedTerminalView.swift
+++ b/ContainerGUI/Terminal/EmbeddedTerminalView.swift
@@ -10,6 +10,7 @@ import AppKit
 struct EmbeddedTerminalView: NSViewRepresentable {
     let executable: String
     let arguments: [String]
+    let onExit: (Int32?) -> Void
 
     func makeNSView(context: Context) -> LocalProcessTerminalView {
         let terminal = LocalProcessTerminalView(frame: NSRect(x: 0, y: 0, width: 640, height: 320))
@@ -23,30 +24,112 @@ struct EmbeddedTerminalView: NSViewRepresentable {
         return terminal
     }
 
-    func updateNSView(_ nsView: LocalProcessTerminalView, context: Context) {}
+    func updateNSView(_ nsView: LocalProcessTerminalView, context: Context) {
+        context.coordinator.onExit = onExit
+    }
 
-    func makeCoordinator() -> Coordinator { Coordinator() }
+    func makeCoordinator() -> Coordinator { Coordinator(onExit: onExit) }
 
     final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
+        var onExit: (Int32?) -> Void
+
+        init(onExit: @escaping (Int32?) -> Void) {
+            self.onExit = onExit
+        }
+
         func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
         func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
-        func processTerminated(source: TerminalView, exitCode: Int32?) {}
+
+        func processTerminated(source: TerminalView, exitCode: Int32?) {
+            onExit(exitCode)
+        }
+    }
+}
+
+/// Shown when the shell exits, in place of a terminal that would otherwise just
+/// sit there frozen with no explanation.
+struct TerminalExitBanner: View {
+    let exitCode: Int32?
+    let restart: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "terminal")
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button(String(localized: "Połącz ponownie"), action: restart)
+                .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private var message: String {
+        guard let exitCode, exitCode != 0 else {
+            return String(localized: "Powłoka zakończona.")
+        }
+        return String(format: String(localized: "Powłoka zakończona (kod %d)."), exitCode)
     }
 }
 
 /// Convenience view that opens an interactive shell inside a running container.
+///
+/// The engine is switchable (Settings → Terminal) because Ghostty's embedding API
+/// is not stable upstream yet; see `TerminalEngine`.
 struct ContainerTerminalView: View {
     let containerID: String
 
+    @AppStorage(TerminalEngine.storageKey) private var engineRawValue = TerminalEngine.default.rawValue
+    /// Recreates the terminal after the shell exits — the views key off this.
+    @State private var sessionID = UUID()
+    @State private var exitCode: Int32?
+    @State private var didExit = false
+
+    private var engine: TerminalEngine {
+        TerminalEngine(rawValue: engineRawValue) ?? .default
+    }
+
+    private var arguments: [String] { ["exec", "-it", containerID, "sh"] }
+
     var body: some View {
         if let binary = BinaryResolver.resolve() {
-            EmbeddedTerminalView(
-                executable: binary,
-                arguments: ["exec", "-it", containerID, "sh"]
-            )
+            VStack(spacing: 0) {
+                terminal(binary: binary)
+                if didExit {
+                    Divider()
+                    TerminalExitBanner(exitCode: exitCode, restart: restart)
+                }
+            }
         } else {
             EmptyStateView(symbol: "terminal", title: String(localized: "Nie znaleziono narzędzia container"))
         }
+    }
+
+    @ViewBuilder
+    private func terminal(binary: String) -> some View {
+        switch engine {
+        case .swiftTerm:
+            EmbeddedTerminalView(executable: binary, arguments: arguments, onExit: shellExited)
+                .id(sessionID)
+        case .ghostty:
+            GhosttyTerminalView(executable: binary, arguments: arguments, onExit: shellExited)
+                .id(sessionID)
+        }
+    }
+
+    private func shellExited(_ code: Int32?) {
+        exitCode = code
+        didExit = true
+    }
+
+    private func restart() {
+        didExit = false
+        exitCode = nil
+        sessionID = UUID()
     }
 }

--- a/ContainerGUI/Terminal/GhosttyTerminalView.swift
+++ b/ContainerGUI/Terminal/GhosttyTerminalView.swift
@@ -1,0 +1,49 @@
+import GhosttyTerminal
+import SwiftUI
+
+/// The container shell rendered by Ghostty's engine (libghostty).
+///
+/// Nothing is piped through the app here: with the `.exec` backend libghostty
+/// spawns the process itself and owns the PTY, the window size and the exit
+/// report. The process to run is handed over as a ghostty `command` config line —
+/// libghostty has no per-surface command field, so each terminal gets its own
+/// controller carrying its own config.
+struct GhosttyTerminalView: View {
+    let executable: String
+    let arguments: [String]
+    let onExit: (Int32?) -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @StateObject private var state: TerminalViewState
+
+    init(executable: String, arguments: [String], onExit: @escaping (Int32?) -> Void) {
+        self.executable = executable
+        self.arguments = arguments
+        self.onExit = onExit
+
+        let command = TerminalCommandLine.string(executable: executable, arguments: arguments)
+        _state = StateObject(wrappedValue: TerminalViewState(
+            controller: TerminalController { builder in
+                builder.withCustom("command", command)
+                builder.withWindowPaddingX(8)
+                builder.withWindowPaddingY(6)
+            }
+        ))
+    }
+
+    var body: some View {
+        TerminalSurfaceView(context: state)
+            .onAppear {
+                state.configuration = TerminalSurfaceOptions(backend: .exec)
+                state.onClose = { [state] _ in
+                    onExit(state.lastCommandExitCode.map(Int32.init))
+                }
+                applyColorScheme()
+            }
+            .onChange(of: colorScheme) { applyColorScheme() }
+    }
+
+    private func applyColorScheme() {
+        state.controller.setColorScheme(colorScheme == .dark ? .dark : .light)
+    }
+}

--- a/ContainerGUI/Terminal/TerminalEngine.swift
+++ b/ContainerGUI/Terminal/TerminalEngine.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Which engine draws the embedded container shell.
+///
+/// SwiftTerm draws through CoreText and is the default. Ghostty (libghostty)
+/// renders with Metal — sharper glyphs, ligatures, better emoji — but its
+/// embedding API is explicitly not stabilized upstream ("used primarily by the
+/// macOS app, may change significantly between releases"), and the full library
+/// only reaches us through a third-party build. So it stays opt-in until that
+/// settles; switching back is a setting, not a rebuild.
+///
+/// Deliberately free of SwiftUI so the logic tests can compile this file on its
+/// own, the way the rest of the headless test bundle works.
+enum TerminalEngine: String, CaseIterable, Identifiable {
+    case swiftTerm
+    case ghostty
+
+    /// UserDefaults key shared by the Settings picker and the terminal view.
+    static let storageKey = "terminalEngine"
+    static let `default` = TerminalEngine.swiftTerm
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .swiftTerm: String(localized: "Wbudowany (SwiftTerm)")
+        case .ghostty: String(localized: "Ghostty — Metal (eksperymentalny)")
+        }
+    }
+}
+
+/// Builds the single command line that Ghostty's `command` config key takes.
+///
+/// Kept separate from the view so the quoting is testable: the path to the
+/// `container` CLI is user-configurable in Settings and may contain spaces.
+enum TerminalCommandLine {
+    /// Ghostty runs the command as `login -flp <user> /bin/bash --noprofile --norc
+    /// -c exec -l <command>`, so the host greets us with "Last login: … on
+    /// ttysNNN" above the container's own prompt. Wrapping in `sh -c` lets `clear`
+    /// wipe that line first; it has to stay a plain executable + arguments,
+    /// because a bare `clear; …` would be torn apart by the wrapper above.
+    static func string(executable: String, arguments: [String]) -> String {
+        let inner = rawCommand(executable: executable, arguments: arguments)
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "/bin/sh -c \"clear; exec \(inner)\""
+    }
+
+    static func rawCommand(executable: String, arguments: [String]) -> String {
+        ([executable] + arguments).map(quoted).joined(separator: " ")
+    }
+
+    private static func quoted(_ part: String) -> String {
+        guard part.contains(where: { $0 == " " || $0 == "\t" || $0 == "\"" }) else { return part }
+        return "\"" + part.replacingOccurrences(of: "\"", with: "\\\"") + "\""
+    }
+}

--- a/ContainerGUITests/TerminalEngineTests.swift
+++ b/ContainerGUITests/TerminalEngineTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+/// Verifies the terminal engine flag and the command line handed to Ghostty.
+///
+/// Ghostty takes the child process as a single `command` config line, so the
+/// quoting is the part that can silently break: the path to the `container` CLI
+/// is user-configurable in Settings and may contain spaces.
+final class TerminalEngineTests: XCTestCase {
+
+    // MARK: - Raw command
+
+    func testJoinsExecutableAndArguments() {
+        let command = TerminalCommandLine.rawCommand(
+            executable: "/usr/local/bin/container",
+            arguments: ["exec", "-it", "acme-shop-api", "sh"]
+        )
+        XCTAssertEqual(command, "/usr/local/bin/container exec -it acme-shop-api sh")
+    }
+
+    func testQuotesExecutablePathContainingSpaces() {
+        let command = TerminalCommandLine.rawCommand(
+            executable: "/Users/me/My Tools/container",
+            arguments: ["exec", "-it", "web", "sh"]
+        )
+        XCTAssertEqual(command, "\"/Users/me/My Tools/container\" exec -it web sh")
+    }
+
+    func testEscapesEmbeddedQuotes() {
+        let command = TerminalCommandLine.rawCommand(
+            executable: "/bin/container",
+            arguments: ["exec", "-it", "od\"dziwny", "sh"]
+        )
+        XCTAssertEqual(command, "/bin/container exec -it \"od\\\"dziwny\" sh")
+    }
+
+    func testLeavesOrdinaryArgumentsUnquoted() {
+        let command = TerminalCommandLine.rawCommand(executable: "container", arguments: ["ls"])
+        XCTAssertEqual(command, "container ls")
+    }
+
+    // MARK: - Ghostty command line
+
+    func testWrapsInShellThatClearsTheHostLoginBanner() {
+        // Ghostty launches through `login -flp`, which prints "Last login: …" above
+        // the container's prompt; `clear` before `exec` is what removes it.
+        let command = TerminalCommandLine.string(
+            executable: "/usr/local/bin/container",
+            arguments: ["exec", "-it", "web", "sh"]
+        )
+        XCTAssertEqual(
+            command,
+            "/bin/sh -c \"clear; exec /usr/local/bin/container exec -it web sh\""
+        )
+    }
+
+    func testEscapesQuotesOfTheInnerCommandForTheWrapper() {
+        // A quoted path from rawCommand would otherwise close the wrapper's own
+        // quoting and hand ghostty a command it cannot parse.
+        let command = TerminalCommandLine.string(
+            executable: "/Users/me/My Tools/container",
+            arguments: ["exec", "-it", "web", "sh"]
+        )
+        XCTAssertEqual(
+            command,
+            "/bin/sh -c \"clear; exec \\\"/Users/me/My Tools/container\\\" exec -it web sh\""
+        )
+    }
+
+    // MARK: - Engine flag
+
+    func testDefaultEngineIsSwiftTerm() {
+        // Ghostty's embedding API is not stable upstream, so it must stay opt-in.
+        XCTAssertEqual(TerminalEngine.default, .swiftTerm)
+    }
+
+    func testUnknownStoredValueFallsBackToDefault() {
+        XCTAssertNil(TerminalEngine(rawValue: "kitty"))
+    }
+
+    func testRawValuesAreStableAcrossReleases() {
+        // These strings live in UserDefaults; renaming them silently resets the
+        // user's choice back to the default.
+        XCTAssertEqual(TerminalEngine.swiftTerm.rawValue, "swiftTerm")
+        XCTAssertEqual(TerminalEngine.ghostty.rawValue, "ghostty")
+        XCTAssertEqual(TerminalEngine.storageKey, "terminalEngine")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -19,6 +19,14 @@ packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     from: 2.6.0
+  # Ghostty's terminal engine, as a prebuilt XCFramework. Pinned exactly, not
+  # `from:` — libghostty's embedding API is explicitly not stabilized yet ("used
+  # primarily by the macOS app", may change between releases), so picking up a new
+  # version has to be a deliberate, re-tested decision. Ghostty itself publishes
+  # only ghostty-vt (the VT parser); this package builds the full library.
+  libghostty:
+    url: https://github.com/Lakr233/libghostty-spm
+    exactVersion: 1.3.2
 
 schemes:
   ContainerGUI:
@@ -58,6 +66,8 @@ targets:
         product: Yams
       - package: Sparkle
         product: Sparkle
+      - package: libghostty
+        product: GhosttyTerminal
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.containerdesktop.ContainerGUI
@@ -98,6 +108,7 @@ targets:
       - path: ContainerGUI/CLI/ProcessLineReader.swift
       - path: ContainerGUI/CLI/BinaryResolver.swift
       - path: ContainerGUI/Features/Containers/LogTailLimit.swift
+      - path: ContainerGUI/Terminal/TerminalEngine.swift
       - path: ContainerGUI/Compose
       - path: Fixtures
         buildPhase: resources


### PR DESCRIPTION
Adds Ghostty's engine behind a switch (**Settings → Terminal**), for rendering quality: Metal instead of CoreText — sharper glyphs, ligatures, better emoji. **SwiftTerm stays the default.**

## Why opt-in
libghostty's embedding API is explicitly not stabilized (*"used primarily by the macOS app… may change significantly between releases"*), and Ghostty officially publishes only `ghostty-vt.xcframework` — the VT parser, no rendering. The full library reaches us through a third-party build (`Lakr233/libghostty-spm`, MIT), so it is pinned with `exactVersion`, never `from:`. Reverting is a setting, not a revert.

## Smaller than planned
The approved plan called for a PTY bridge — pumping bytes between `SwiftTerm.LocalProcess` and libghostty's in-memory session. Reading the package's sources showed an `.exec` backend: libghostty spawns `container exec -it <id> sh` itself and owns the PTY, resizing and the exit report. The bridge, and all its Swift-6 concurrency risk, is gone.

## Two traps worth documenting
- libghostty runs the command as `login -flp <user> /bin/bash --noprofile --norc -c exec -l <cmd>`. A bare `clear; …` gets torn apart by that wrapper (Ghostty answered with *"failed to launch the requested command"*), and without a `clear` the host's `Last login: … on ttys006` sits above the container's prompt. Hence `/bin/sh -c "clear; exec …"`, with the quoting under test — the CLI path is user-configurable and may contain spaces.
- The XCFramework ships a **static** library, so nothing extra needs signing; the ad-hoc-signed Release app launches from a DMG unchanged.

## Also fixed
`processTerminated` was an empty stub — the terminal just froze when the shell exited. Both engines now report the exit and offer **Reconnect**.

## Size
| | before | after |
| --- | --- | --- |
| Release `.app` | — | 42 MB |
| DMG | 6 MB | 16 MB |

~10 MB per Sparkle update. Roughly half of the `.app` growth is the x86_64 slice; since the app requires Apple Silicon anyway, `ARCHS = arm64` would cut it — deliberately left out of this PR.

## Verification
- Ghostty engine runs a real shell in a demo container (rendering, colours, prompt) — checked visually
- 73 tests pass (9 new: command-line quoting, engine flag defaults and raw-value stability)
- Release build + DMG staging + launch of the ad-hoc-signed app
- CPU with the terminal visible: 0.7%
- **Not** visually verified: the exit banner (implemented, but UI scripting failed on that last step)

## Noted, not fixed here
The Logs tab pegs a core at ~100% CPU — reproduces identically on **both** engines, so it predates this change. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
