### PR TITLE
Logs: tail by default, and stop re-rendering the whole view per line

### DIFF
--- a/ContainerGUI/CLI/ProcessLineReader.swift
+++ b/ContainerGUI/CLI/ProcessLineReader.swift
@@ -78,6 +78,10 @@ final class ProcessLineReader: @unchecked Sendable {
         if process.isRunning { process.terminate() }
     }
 
+    /// Whether the child is still alive — an abandoned stream must not leave one
+    /// behind (`container logs --follow` held on and later log views hung).
+    var isRunning: Bool { process.isRunning }
+
     // MARK: - Buffer handling
 
     private func drain(appending chunk: Data) -> [String] {

--- a/ContainerGUI/Features/Containers/LogTailLimit.swift
+++ b/ContainerGUI/Features/Containers/LogTailLimit.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// How much history to ask the CLI for.
+///
+/// `container logs` prints *everything* when `-n` is omitted, which for a
+/// long-running container means megabytes streamed line by line before the first
+/// screenful is usable. Tailing is the default; the whole log stays one click
+/// away.
+enum LogTailLimit: Int, CaseIterable, Identifiable {
+    case last200 = 200
+    case last1000 = 1000
+    case last5000 = 5000
+    case all = 0
+
+    static let storageKey = "logTailLines"
+    static let `default` = LogTailLimit.last1000
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: String(localized: "wszystko")
+        default: String(format: String(localized: "ostatnie %d"), rawValue)
+        }
+    }
+
+    /// Arguments for `container logs`. Omitting `-n` is what asks for everything.
+    var arguments: [String] {
+        self == .all ? [] : ["-n", "\(rawValue)"]
+    }
+
+    /// Lines kept in memory. "Everything" still needs a ceiling — without one a
+    /// container that has been chatting for weeks would grow the view until the
+    /// app dies. Beyond it the oldest lines are dropped, newest always kept.
+    var retainedLines: Int {
+        self == .all ? 100_000 : rawValue * 2
+    }
+}

--- a/ContainerGUI/Features/Containers/LogTailLimit.swift
+++ b/ContainerGUI/Features/Containers/LogTailLimit.swift
@@ -25,8 +25,13 @@ enum LogTailLimit: Int, CaseIterable, Identifiable {
     }
 
     /// Arguments for `container logs`. Omitting `-n` is what asks for everything.
+    ///
+    /// One line more than asked for: the CLI's tail reader seeks back in 1 KiB
+    /// chunks and hands back the *first* line cut mid-way, so it arrives as a
+    /// fragment (apple/container#2022, still present in 1.2.0). The extra line is
+    /// dropped on arrival, leaving exactly `rawValue` intact ones.
     var arguments: [String] {
-        self == .all ? [] : ["-n", "\(rawValue)"]
+        self == .all ? [] : ["-n", "\(rawValue + 1)"]
     }
 
     /// Lines kept in memory. "Everything" still needs a ceiling — without one a

--- a/ContainerGUI/Features/Containers/LogsView.swift
+++ b/ContainerGUI/Features/Containers/LogsView.swift
@@ -4,10 +4,15 @@ import SwiftUI
 struct LogsView: View {
     let containerID: String
 
+    @AppStorage(LogTailLimit.storageKey) private var tailRawValue = LogTailLimit.default.rawValue
     @State private var lines: [LogLine] = []
     @State private var autoscroll = true
     @State private var showTimestamps = false
     @State private var streamEnded = false
+
+    private var tail: LogTailLimit {
+        LogTailLimit(rawValue: tailRawValue) ?? .default
+    }
 
     var body: some View {
         Group {
@@ -35,6 +40,18 @@ struct LogsView: View {
                 )
                 .overlay(alignment: .bottomTrailing) {
                     HStack(spacing: 6) {
+                        Picker(selection: $tailRawValue) {
+                            ForEach(LogTailLimit.allCases) { limit in
+                                Text(limit.title).tag(limit.rawValue)
+                            }
+                        } label: {
+                            EmptyView()
+                        }
+                        .pickerStyle(.menu)
+                        .controlSize(.small)
+                        .fixedSize()
+                        .help(String(localized: "Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę."))
+
                         Button {
                             copyAll()
                         } label: {
@@ -55,7 +72,8 @@ struct LogsView: View {
                 }
             }
         }
-        .task(id: containerID) {
+        // Restarts the stream when the container *or* the amount of history changes.
+        .task(id: "\(containerID)#\(tailRawValue)") {
             await streamLogs()
         }
     }
@@ -81,20 +99,38 @@ struct LogsView: View {
     }()
 
     private func streamLogs() async {
+        let tail = tail
         lines = []
         streamEnded = false
-        let stream = ContainerCLI.shared.stream(["logs", "--follow", containerID])
+        let stream = ContainerCLI.shared.stream(["logs"] + tail.arguments + ["--follow", containerID])
+        // Appending line by line would republish the array — and re-render the text
+        // view — thousands of times while the backlog arrives. Collect and flush.
+        var pending: [LogLine] = []
+        var lastFlush = ContinuousClock.now
         do {
             for try await line in stream {
-                lines.append(LogLine(text: line))
-                if lines.count > 2000 {
-                    lines.removeFirst(lines.count - 2000)
-                }
+                pending.append(LogLine(text: line))
+                let now = ContinuousClock.now
+                guard pending.count >= 250 || now - lastFlush > .milliseconds(120) else { continue }
+                append(pending, tail: tail)
+                pending.removeAll(keepingCapacity: true)
+                lastFlush = now
             }
         } catch {
-            lines.append(LogLine(text: String(format: String(localized: "[błąd strumienia logów: %@]"), error.localizedDescription)))
+            pending.append(LogLine(text: String(format: String(localized: "[błąd strumienia logów: %@]"), error.localizedDescription)))
         }
+        append(pending, tail: tail)
         streamEnded = true
+    }
+
+    private func append(_ newLines: [LogLine], tail: LogTailLimit) {
+        guard !newLines.isEmpty else { return }
+        lines.append(contentsOf: newLines)
+        guard lines.count > tail.retainedLines else { return }
+        // Trimmed in chunks, not down to the limit on every line: dropping the
+        // first line changes the array's head, which makes LogTextView rebuild
+        // its whole storage. Once per chunk is affordable; once per line is not.
+        lines.removeFirst(lines.count - tail.retainedLines * 3 / 4)
     }
 }
 

--- a/ContainerGUI/Features/Containers/LogsView.swift
+++ b/ContainerGUI/Features/Containers/LogsView.swift
@@ -103,15 +103,34 @@ struct LogsView: View {
         lines = []
         streamEnded = false
         let stream = ContainerCLI.shared.stream(["logs"] + tail.arguments + ["--follow", containerID])
-        // Appending line by line would republish the array — and re-render the text
-        // view — thousands of times while the backlog arrives. Collect and flush.
+        // Two phases. While the backlog pours in, lines are only collected — a
+        // container with thousands of lines of history would otherwise be drawn a
+        // batch at a time, all of it, and only the last screenful matters. After
+        // `backlogWindow` whatever survived trimming is drawn once, and from then
+        // on lines are appended as they arrive (still batched, because publishing
+        // per line re-renders the view).
+        let start = ContinuousClock.now
         var pending: [LogLine] = []
-        var lastFlush = ContinuousClock.now
+        var lastFlush = start
+        var showingBacklog = true
         do {
             for try await line in stream {
                 pending.append(LogLine(text: line))
                 let now = ContinuousClock.now
-                guard pending.count >= 250 || now - lastFlush > .milliseconds(120) else { continue }
+                if showingBacklog {
+                    trimToRetained(&pending, tail: tail)
+                    guard now - start > Self.backlogWindow else { continue }
+                    showingBacklog = false
+                    // `arguments` asks for one line more than wanted because the
+                    // CLI truncates the first one (apple/container#2022). Getting
+                    // more lines than asked for means history was cut — so that
+                    // first line is the fragment, and goes.
+                    if tail != .all, pending.count > tail.rawValue {
+                        pending.removeFirst()
+                    }
+                } else {
+                    guard pending.count >= 250 || now - lastFlush > .milliseconds(120) else { continue }
+                }
                 append(pending, tail: tail)
                 pending.removeAll(keepingCapacity: true)
                 lastFlush = now
@@ -123,6 +142,9 @@ struct LogsView: View {
         streamEnded = true
     }
 
+    /// How long the initial backlog is collected before anything is drawn.
+    private static let backlogWindow = Duration.milliseconds(400)
+
     private func append(_ newLines: [LogLine], tail: LogTailLimit) {
         guard !newLines.isEmpty else { return }
         lines.append(contentsOf: newLines)
@@ -131,6 +153,12 @@ struct LogsView: View {
         // first line changes the array's head, which makes LogTextView rebuild
         // its whole storage. Once per chunk is affordable; once per line is not.
         lines.removeFirst(lines.count - tail.retainedLines * 3 / 4)
+    }
+
+    /// Caps the not-yet-drawn backlog, keeping the newest lines.
+    private func trimToRetained(_ buffer: inout [LogLine], tail: LogTailLimit) {
+        guard buffer.count > tail.retainedLines else { return }
+        buffer.removeFirst(buffer.count - tail.retainedLines)
     }
 }
 

--- a/ContainerGUI/Resources/en.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/en.lproj/Localizable.strings
@@ -484,3 +484,8 @@
 /* Features/Containers/ContainersView.swift — Compose project removal */
 "Usuń projekt" = "Remove project";
 "Wszystkie kontenery projektu %@ zostaną usunięte." = "All containers in project %@ will be removed.";
+
+/* Features/Containers/LogsView.swift — how much history to fetch */
+"ostatnie %d" = "last %d";
+"wszystko" = "everything";
+"Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę." = "How much history to fetch. A full log can be very large — loading and drawing it will take a moment.";

--- a/ContainerGUI/Resources/pl.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/pl.lproj/Localizable.strings
@@ -484,3 +484,8 @@
 /* Features/Containers/ContainersView.swift — Compose project removal */
 "Usuń projekt" = "Usuń projekt";
 "Wszystkie kontenery projektu %@ zostaną usunięte." = "Wszystkie kontenery projektu %@ zostaną usunięte.";
+
+/* Features/Containers/LogsView.swift — how much history to fetch */
+"ostatnie %d" = "ostatnie %d";
+"wszystko" = "wszystko";
+"Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę." = "Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę.";

--- a/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -484,3 +484,8 @@
 /* Features/Containers/ContainersView.swift — Compose project removal */
 "Usuń projekt" = "删除项目";
 "Wszystkie kontenery projektu %@ zostaną usunięte." = "项目 %@ 中的所有容器都将被删除。";
+
+/* Features/Containers/LogsView.swift — how much history to fetch */
+"ostatnie %d" = "最后 %d 行";
+"wszystko" = "全部";
+"Ile historii pobrać. Cały log może być bardzo duży — wczytanie i wyrysowanie zajmie wtedy chwilę." = "获取多少历史记录。完整日志可能非常大 —— 加载和绘制会需要一些时间。";

--- a/ContainerGUITests/LogTailLimitTests.swift
+++ b/ContainerGUITests/LogTailLimitTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// Verifies how much log history the app asks `container logs` for.
+///
+/// The CLI prints the *entire* log when `-n` is omitted, which is what made the
+/// log viewer crawl on long-running containers — so which cases pass `-n` and
+/// which deliberately do not is worth pinning down.
+final class LogTailLimitTests: XCTestCase {
+
+    // MARK: - CLI arguments
+
+    func testTailedLimitsPassLineCount() {
+        XCTAssertEqual(LogTailLimit.last200.arguments, ["-n", "200"])
+        XCTAssertEqual(LogTailLimit.last1000.arguments, ["-n", "1000"])
+        XCTAssertEqual(LogTailLimit.last5000.arguments, ["-n", "5000"])
+    }
+
+    func testEverythingOmitsTheFlag() {
+        // Omitting -n is exactly what asks the CLI for the whole log.
+        XCTAssertEqual(LogTailLimit.all.arguments, [])
+    }
+
+    // MARK: - Retention
+
+    func testRetainsTwiceTheRequestedLines() {
+        // Headroom above the fetched backlog, so following a live container does
+        // not start trimming immediately.
+        XCTAssertEqual(LogTailLimit.last200.retainedLines, 400)
+        XCTAssertEqual(LogTailLimit.last1000.retainedLines, 2000)
+        XCTAssertEqual(LogTailLimit.last5000.retainedLines, 10_000)
+    }
+
+    func testEverythingStillHasACeiling() {
+        // Unbounded growth would eventually take the app down with it.
+        XCTAssertEqual(LogTailLimit.all.retainedLines, 100_000)
+    }
+
+    // MARK: - Defaults
+
+    func testDefaultTailsRatherThanFetchingEverything() {
+        XCTAssertEqual(LogTailLimit.default, .last1000)
+        XCTAssertFalse(LogTailLimit.default.arguments.isEmpty)
+    }
+
+    func testRawValuesAreStableAcrossReleases() {
+        // Stored in UserDefaults; changing them silently resets the user's choice.
+        XCTAssertEqual(LogTailLimit.storageKey, "logTailLines")
+        XCTAssertEqual(LogTailLimit.all.rawValue, 0)
+        XCTAssertEqual(LogTailLimit(rawValue: 1000), .last1000)
+        XCTAssertNil(LogTailLimit(rawValue: 777))
+    }
+}

--- a/ContainerGUITests/LogTailLimitTests.swift
+++ b/ContainerGUITests/LogTailLimitTests.swift
@@ -9,10 +9,12 @@ final class LogTailLimitTests: XCTestCase {
 
     // MARK: - CLI arguments
 
-    func testTailedLimitsPassLineCount() {
-        XCTAssertEqual(LogTailLimit.last200.arguments, ["-n", "200"])
-        XCTAssertEqual(LogTailLimit.last1000.arguments, ["-n", "1000"])
-        XCTAssertEqual(LogTailLimit.last5000.arguments, ["-n", "5000"])
+    func testTailedLimitsAskForOneExtraLine() {
+        // One more than wanted: the CLI hands back a truncated first line
+        // (apple/container#2022, still present in 1.2.0), which the view drops.
+        XCTAssertEqual(LogTailLimit.last200.arguments, ["-n", "201"])
+        XCTAssertEqual(LogTailLimit.last1000.arguments, ["-n", "1001"])
+        XCTAssertEqual(LogTailLimit.last5000.arguments, ["-n", "5001"])
     }
 
     func testEverythingOmitsTheFlag() {

--- a/ContainerGUITests/ProcessLineReaderTests.swift
+++ b/ContainerGUITests/ProcessLineReaderTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+/// Verifies that a burst of output survives the reader intact.
+///
+/// Containers like SQL Server dump thousands of lines the moment they start, and
+/// the log viewer showed them torn apart mid-word ("Parallel redo is shutdown for
+/// / database / 'e2610" on separate lines) — while `container logs` piped to a
+/// file was clean, so the damage happened on the way through here.
+final class ProcessLineReaderTests: XCTestCase {
+
+    /// One line per iteration, long enough that a burst spans many pipe reads.
+    private func burstScript(lines: Int) -> String {
+        "i=1; while [ $i -le \(lines) ]; do "
+            + "echo \"line-$i AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            + "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+            + "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\"; "
+            + "i=$((i+1)); done"
+    }
+
+    func testBurstOfOutputArrivesLineByLineInOrder() async throws {
+        let expected = 5000
+        let reader = ProcessLineReader(
+            binary: "/bin/sh",
+            arguments: ["-c", burstScript(lines: expected)]
+        )
+
+        var received: [String] = []
+        for try await line in reader.lines() {
+            received.append(line)
+        }
+
+        XCTAssertEqual(received.count, expected, "lines were split or merged in transit")
+        for (offset, line) in received.enumerated() {
+            XCTAssertTrue(
+                line.hasPrefix("line-\(offset + 1) "),
+                "line \(offset + 1) arrived as \"\(line.prefix(40))…\""
+            )
+        }
+    }
+
+    func testMultiByteCharactersSurviveChunkBoundaries() async throws {
+        // A chunk boundary landing inside a multi-byte character would leave
+        // replacement characters behind.
+        let script = "i=1; while [ $i -le 2000 ]; do echo \"$i zażółć gęślą jaźń 中文 🚀\"; i=$((i+1)); done"
+        let reader = ProcessLineReader(binary: "/bin/sh", arguments: ["-c", script])
+
+        var count = 0
+        for try await line in reader.lines() {
+            count += 1
+            XCTAssertFalse(line.contains("\u{FFFD}"), "mangled UTF-8 in: \(line)")
+            XCTAssertTrue(line.hasSuffix("zażółć gęślą jaźń 中文 🚀"), "truncated: \(line)")
+        }
+        XCTAssertEqual(count, 2000)
+    }
+
+    func testProcessIsGoneAfterTheConsumingTaskIsCancelled() async throws {
+        // This is the path the log view actually takes: `.task(id:)` cancels the
+        // previous stream when you switch containers. A survivor here is what left
+        // `container logs --follow` running in the background.
+        let reader = ProcessLineReader(
+            binary: "/bin/sh",
+            arguments: ["-c", "while true; do echo tick; sleep 0.2; done"]
+        )
+        let started = expectation(description: "first line arrived")
+
+        let task = Task {
+            var first = true
+            for try await _ in reader.lines() {
+                if first { started.fulfill(); first = false }
+            }
+        }
+        await fulfillment(of: [started], timeout: 5)
+        task.cancel()
+        _ = try? await task.value
+
+        try await Task.sleep(for: .milliseconds(700))
+        XCTAssertFalse(reader.isRunning, "cancelling the consumer left the child running")
+    }
+
+    func testProcessIsGoneAfterTheStreamIsAbandoned() async throws {
+        // Leaving `container logs --follow` running is what stopped later log
+        // views from loading.
+        let reader = ProcessLineReader(
+            binary: "/bin/sh",
+            arguments: ["-c", "while true; do echo tick; sleep 0.2; done"]
+        )
+
+        var seen = 0
+        for try await _ in reader.lines() {
+            seen += 1
+            if seen == 3 { break }   // abandon the stream mid-flight
+        }
+
+        // Give termination a moment to propagate.
+        try await Task.sleep(for: .milliseconds(500))
+        XCTAssertFalse(reader.isRunning, "the child process outlived its stream")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -97,6 +97,7 @@ targets:
       - path: ContainerGUI/CLI/ContainerCLI.swift
       - path: ContainerGUI/CLI/ProcessLineReader.swift
       - path: ContainerGUI/CLI/BinaryResolver.swift
+      - path: ContainerGUI/Features/Containers/LogTailLimit.swift
       - path: ContainerGUI/Compose
       - path: Fixtures
         buildPhase: resources


### PR DESCRIPTION
Fixes the log viewer crawling on containers with real history. Two separate causes behind one symptom:

**1. It fetched everything, every time.** `container logs --follow` prints the whole log when `-n` is omitted, so opening the tab streamed the entire history before the newest lines — the part you actually want — appeared.

**2. Worse, and independent of log size:** once the buffer passed its 2000-line cap, `lines.removeFirst` changed the array's head on *every new line*. `LogTextView` treats a changed head as a reset, so it cleared its storage and re-rendered all 2000 lines — per line. A container printing once a second pegged a core indefinitely, with no large log needed.

## What changed
- **History picker** in the log toolbar — *last 200 / 1000 / 5000 / everything* — persisted, default **last 1000**. `-n` bounds the backlog before it ever reaches the app.
- **"Everything" still means everything**: `-n` is omitted and the full log is shown. The only ceiling is what stays in memory (100k lines), so a container that has been logging for weeks can't take the app down with it.
- **Batched appends** (250 lines or 120 ms) instead of republishing the array per line.
- **Chunked trimming** down to 75% of the retained window, so the expensive rebuild happens once per chunk instead of once per line.

## Measured
Container with 7492 lines of history, log tab open and following:

| | CPU |
| --- | --- |
| before | 100.3% |
| after, *last 1000* | 2.4% |
| after, *everything* | 3.6% |

Verified visually as well: picker present, colouring and autoscroll unaffected. 70 tests pass, 6 new ones covering which cases pass `-n`, which deliberately don't, the retention ceiling and the stored raw values.

Discovered while measuring PR #9 — it reproduced identically with both terminal engines, which is what ruled out Ghostty as the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second pass, after watching it on a container with 8723 lines

- **Only the tail is drawn on open.** The backlog is collected for 400 ms, then whatever survives trimming is drawn once. Before, a long history was rendered batch after batch — all of it — when only the last screenful matters. Opening that log now costs **0.08 s of CPU** (0.06 s in *everything* mode).
- **Worked around the CLI's `-n` truncation.** `container logs -n N` returns a truncated *first* line: the tail reader seeks back in 1 KiB chunks and cuts mid-line — [apple/container#2022](https://github.com/apple/container/issues/2022), [#1967](https://github.com/apple/container/issues/1967). Verified still present in **CLI 1.2.0**: 1011 bytes returned for a 2001-byte line. The app now asks for `N+1` lines and drops the first one when history was actually cut.

## Torn-apart log lines: not reproduced

A report of lines split mid-word (`Parallel redo is shutdown for` / `database` / `'e2610` on separate lines) is **not** explained by anything in this PR. What was ruled out:

- `container logs` output is byte-identical piped to a file and read by a deliberately slow reader that fills the pipe — so the CLI does not corrupt the stream under back-pressure.
- `ProcessLineReader` is clean under load: 4 new tests cover a 5000-line burst arriving intact and in order, multi-byte characters surviving chunk boundaries, and the child process being reaped both when the stream is abandoned and when the consuming task is cancelled.

That leaves the rendering path. Needs a reproduction before guessing further.

