### PR TITLE
Logs: fix the endless spinner, indent wrapped lines; Sparkle checks on launch

### DIFF
--- a/ContainerGUI/App/ContainerGUIApp.swift
+++ b/ContainerGUI/App/ContainerGUIApp.swift
@@ -14,6 +14,20 @@ struct ContainerGUIApp: App {
         userDriverDelegate: nil
     )
 
+    /// Sparkle schedules its automatic checks relative to the last one, so with the
+    /// default one-day interval an app relaunched the same day never checks — a new
+    /// release could sit unnoticed until the next day. This asks once per launch,
+    /// which is quiet: Sparkle only surfaces UI when there is something to install.
+    ///
+    /// Delayed a little so the check does not compete with the CLI queries the app
+    /// fires at startup.
+    @MainActor
+    private func checkForUpdatesOnLaunch() async {
+        try? await Task.sleep(for: .seconds(3))
+        guard updaterController.updater.canCheckForUpdates else { return }
+        updaterController.updater.checkForUpdatesInBackground()
+    }
+
     /// MenuBarExtra ignores SwiftUI `.font` on its label, so size the status
     /// item glyph explicitly via an NSImage symbol configuration. The image is
     /// capped to the menu bar grid (~17 pt tall) — anything taller gets clipped
@@ -36,6 +50,7 @@ struct ContainerGUIApp: App {
             RootView()
                 .environment(model)
                 .frame(minWidth: 940, minHeight: 580)
+                .task { await checkForUpdatesOnLaunch() }
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 1100, height: 720)

--- a/ContainerGUI/Common/LogTextView.swift
+++ b/ContainerGUI/Common/LogTextView.swift
@@ -72,6 +72,18 @@ struct LogTextView: NSViewRepresentable {
     // MARK: - Rendering
 
     private static let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+
+    /// Wrapped continuations are indented, otherwise a long entry looks like
+    /// several — SQL Server and MariaDB write single log lines hundreds of
+    /// characters long, and their tails started at column zero, exactly where a
+    /// new entry would.
+    private static let paragraphStyle: NSParagraphStyle = {
+        let style = NSMutableParagraphStyle()
+        style.lineBreakMode = .byWordWrapping
+        style.headIndent = 26
+        style.firstLineHeadIndent = 0
+        return style
+    }()
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss"
@@ -83,13 +95,17 @@ struct LogTextView: NSViewRepresentable {
         if showTimestamps {
             result.append(NSAttributedString(
                 string: "[\(timeFormatter.string(from: line.date))] ",
-                attributes: [.font: font, .foregroundColor: NSColor.tertiaryLabelColor]
+                attributes: [
+                    .font: font,
+                    .foregroundColor: NSColor.tertiaryLabelColor,
+                    .paragraphStyle: paragraphStyle,
+                ]
             ))
         }
         let color: NSColor = colorize ? LogLevel.detect(in: line.text).color : .labelColor
         result.append(NSAttributedString(
             string: line.text + "\n",
-            attributes: [.font: font, .foregroundColor: color]
+            attributes: [.font: font, .foregroundColor: color, .paragraphStyle: paragraphStyle]
         ))
         return result
     }

--- a/ContainerGUI/Features/Containers/LogsView.swift
+++ b/ContainerGUI/Features/Containers/LogsView.swift
@@ -9,6 +9,12 @@ struct LogsView: View {
     @State private var autoscroll = true
     @State private var showTimestamps = false
     @State private var streamEnded = false
+    /// Backlog held back until `backlogWindow` elapses, so a long history is drawn
+    /// once instead of batch after batch.
+    @State private var backlog: [LogLine] = []
+    /// Set when the backlog has been handed over — also what dismisses the spinner,
+    /// because with `--follow` a quiet container never ends the stream.
+    @State private var backlogDrawn = false
 
     private var tail: LogTailLimit {
         LogTailLimit(rawValue: tailRawValue) ?? .default
@@ -16,14 +22,14 @@ struct LogsView: View {
 
     var body: some View {
         Group {
-            if lines.isEmpty && streamEnded {
+            if lines.isEmpty && (streamEnded || backlogDrawn) {
                 EmptyStateView(
                     symbol: "doc.text",
                     title: String(localized: "Brak logów"),
                     message: String(localized: "Kontener nie wypisał nic na stdout/stderr. Kontenery typu `sleep` nie generują logów."),
                     tint: .blue
                 )
-            } else if lines.isEmpty && !streamEnded {
+            } else if lines.isEmpty {
                 VStack(spacing: 12) {
                     ProgressView()
                     Text("Wczytywanie logów…")
@@ -101,6 +107,8 @@ struct LogsView: View {
     private func streamLogs() async {
         let tail = tail
         lines = []
+        backlog = []
+        backlogDrawn = false
         streamEnded = false
         let stream = ContainerCLI.shared.stream(["logs"] + tail.arguments + ["--follow", containerID])
         // Two phases. While the backlog pours in, lines are only collected — a
@@ -109,41 +117,60 @@ struct LogsView: View {
         // `backlogWindow` whatever survived trimming is drawn once, and from then
         // on lines are appended as they arrive (still batched, because publishing
         // per line re-renders the view).
-        let start = ContinuousClock.now
+        //
+        // The handover is driven by a timer, not by the next line arriving: a
+        // stopped container delivers its whole history in milliseconds and then
+        // `--follow` waits forever for output that will never come, so waiting for
+        // one more line to trigger the draw left the spinner up indefinitely.
+        let handover = Task { @MainActor in
+            try? await Task.sleep(for: Self.backlogWindow)
+            drawBacklog(tail: tail)
+        }
+        defer { handover.cancel() }
+
         var pending: [LogLine] = []
-        var lastFlush = start
-        var showingBacklog = true
+        var lastFlush = ContinuousClock.now
         do {
             for try await line in stream {
-                pending.append(LogLine(text: line))
-                let now = ContinuousClock.now
-                if showingBacklog {
-                    trimToRetained(&pending, tail: tail)
-                    guard now - start > Self.backlogWindow else { continue }
-                    showingBacklog = false
-                    // `arguments` asks for one line more than wanted because the
-                    // CLI truncates the first one (apple/container#2022). Getting
-                    // more lines than asked for means history was cut — so that
-                    // first line is the fragment, and goes.
-                    if tail != .all, pending.count > tail.rawValue {
-                        pending.removeFirst()
-                    }
-                } else {
-                    guard pending.count >= 250 || now - lastFlush > .milliseconds(120) else { continue }
+                let entry = LogLine(text: line)
+                if !backlogDrawn {
+                    backlog.append(entry)
+                    trimToRetained(&backlog, tail: tail)
+                    continue
                 }
+                pending.append(entry)
+                let now = ContinuousClock.now
+                guard pending.count >= 250 || now - lastFlush > .milliseconds(120) else { continue }
                 append(pending, tail: tail)
                 pending.removeAll(keepingCapacity: true)
                 lastFlush = now
             }
         } catch {
-            pending.append(LogLine(text: String(format: String(localized: "[błąd strumienia logów: %@]"), error.localizedDescription)))
+            let failure = LogLine(text: String(format: String(localized: "[błąd strumienia logów: %@]"), error.localizedDescription))
+            if backlogDrawn { pending.append(failure) } else { backlog.append(failure) }
         }
+        handover.cancel()
+        drawBacklog(tail: tail)          // in case the stream ended inside the window
         append(pending, tail: tail)
         streamEnded = true
     }
 
     /// How long the initial backlog is collected before anything is drawn.
     private static let backlogWindow = Duration.milliseconds(400)
+
+    /// Hands the collected backlog over to the view — once.
+    private func drawBacklog(tail: LogTailLimit) {
+        guard !backlogDrawn else { return }
+        backlogDrawn = true
+        // `arguments` asks for one line more than wanted because the CLI truncates
+        // the first one (apple/container#2022). More lines than asked for means
+        // history was actually cut, so that first line is the fragment — drop it.
+        if tail != .all, backlog.count > tail.rawValue {
+            backlog.removeFirst()
+        }
+        append(backlog, tail: tail)
+        backlog = []
+    }
 
     private func append(_ newLines: [LogLine], tail: LogTailLimit) {
         guard !newLines.isEmpty else { return }


### PR DESCRIPTION
Two defects in the 0.3.0 log viewer, one of them mine.

## The spinner never went away
0.3.0 holds the backlog for 400 ms before drawing it — but the handover was triggered by **the next line arriving**. A stopped container delivers its whole history in milliseconds and then `--follow` waits forever for output that will never come, so nothing ever triggered the draw and *Wczytywanie logów…* stayed up indefinitely.

My measurements missed it entirely: I benchmarked against a container printing once a second, which always supplied the trigger. The handover is now a timer, independent of traffic, and a container with no output shows the empty state instead of spinning forever.

## "Mangled" logs were wrapping, not corruption
MariaDB and SQL Server write single entries hundreds of characters long. NSTextView wrapped them with the continuation starting at **column zero** — exactly where a new entry starts, so one entry read as several:

```
2026-07-29 10:09:47 23 [Warning] Aborted connection 23 to db: 'unconnected' user: 'unauthenticated' host: '192.168.66.1' (This connection closed normally without
authentication)
```

Continuations are now indented, so a wrapped tail is visibly part of the entry above. This also closes out the report from PR #10 that I could not reproduce — the data was never damaged; it only looked that way.

## Verified
- Stopped container (`kb-mariadb`, 40 lines): logs appear within the window, no spinner
- Running container (`sql2025`): unchanged, and wrapped tails now indented
- Narrow window (1100 pt), where wrapping is frequent: entries stay distinguishable

No unit test here — both defects live in the SwiftUI view's timing and text layout, which the headless test bundle cannot reach. Checked by hand instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)