### PR TITLE
Values editor polish: one-of requirements, room to paste, non-blocking schema load

### DIFF
--- a/ContainerGUI/Features/Containers/ContainerCardsView.swift
+++ b/ContainerGUI/Features/Containers/ContainerCardsView.swift
@@ -11,6 +11,8 @@ struct ContainerCardsView: View {
     @Environment(AppModel.self) private var model
 
     @Binding var selection: String?
+    /// Already filtered by the search field in `ContainersView`.
+    let containers: [ContainerInfo]
     let onRecreate: (ContainerInfo) -> Void
     let onRemove: (ContainerInfo) -> Void
     let onRemoveProject: (String, [ContainerInfo]) -> Void
@@ -19,7 +21,7 @@ struct ContainerCardsView: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 8) {
+            LazyVStack(spacing: 5) {
                 ForEach(groups) { group in
                     if let project = group.project {
                         ComposeProjectCard(
@@ -42,8 +44,9 @@ struct ContainerCardsView: View {
                     }
                 }
             }
-            .padding(12)
-            .animation(.smooth(duration: 0.25), value: store.items.map(\.id))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .animation(.smooth(duration: 0.25), value: containers.map(\.id))
         }
         .scrollContentBackground(.hidden)
     }
@@ -56,25 +59,41 @@ struct ContainerCardsView: View {
         let containers: [ContainerInfo]
     }
 
+    /// Running containers first — they are the ones you act on. Within each
+    /// half, and within a project, ordering stays alphabetical so nothing
+    /// jumps around as usage fluctuates.
+    private static func runningFirst(_ containers: [ContainerInfo]) -> [ContainerInfo] {
+        containers.sorted { lhs, rhs in
+            lhs.isRunning == rhs.isRunning ? lhs.id < rhs.id : lhs.isRunning
+        }
+    }
+
     private var groups: [Group] {
         var byProject: [String: [ContainerInfo]] = [:]
         var loose: [ContainerInfo] = []
-        for container in store.items {
+        for container in containers {
             if let project = container.composeProject {
                 byProject[project, default: []].append(container)
             } else {
                 loose.append(container)
             }
         }
-        var result = byProject.keys.sorted().map { project in
-            Group(
-                id: "project:\(project)",
-                project: project,
-                containers: byProject[project]?.sorted { $0.id < $1.id } ?? []
-            )
-        }
+        // Projects with something running float above idle ones.
+        var result = byProject.keys
+            .sorted { lhs, rhs in
+                let lhsRunning = byProject[lhs]?.contains(where: \.isRunning) ?? false
+                let rhsRunning = byProject[rhs]?.contains(where: \.isRunning) ?? false
+                return lhsRunning == rhsRunning ? lhs < rhs : lhsRunning
+            }
+            .map { project in
+                Group(
+                    id: "project:\(project)",
+                    project: project,
+                    containers: Self.runningFirst(byProject[project] ?? [])
+                )
+            }
         if !loose.isEmpty {
-            result.append(Group(id: "loose", project: nil, containers: loose))
+            result.append(Group(id: "loose", project: nil, containers: Self.runningFirst(loose)))
         }
         return result
     }
@@ -98,8 +117,8 @@ struct ContainerCard: View {
     private var usage: ContainerStore.LiveUsage? { store.liveStats[container.id] }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center, spacing: 12) {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 10) {
                 stateTile
                 identity
                 Spacer(minLength: 8)
@@ -110,8 +129,8 @@ struct ContainerCard: View {
                 chipRow
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
         .background(background)
         .overlay(border)
         .contentShape(RoundedRectangle(cornerRadius: 12))
@@ -130,16 +149,16 @@ struct ContainerCard: View {
     /// without relying on colour alone.
     private var stateTile: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 9)
+            RoundedRectangle(cornerRadius: 7)
                 .fill(stateColor.gradient.opacity(container.isRunning ? 1 : 0.35))
-                .frame(width: 38, height: 38)
+                .frame(width: 30, height: 30)
             if isPending {
                 ProgressView()
                     .controlSize(.small)
                     .tint(.white)
             } else {
                 Image(systemName: container.isRunning ? "shippingbox.fill" : "shippingbox")
-                    .font(.system(size: 17, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.white)
             }
         }
@@ -177,7 +196,7 @@ struct ContainerCard: View {
     /// CPU and memory, drawn as compact bars. Only for running containers —
     /// meters pinned at zero would be noise.
     private var meters: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 10) {
             MeterView(
                 label: "CPU",
                 value: usage?.cpuPercent.map { min($0 / 100, 1) },
@@ -191,7 +210,7 @@ struct ContainerCard: View {
                 tint: .purple
             )
         }
-        .frame(width: 168)
+        .frame(width: 176)
         .transition(.opacity.combined(with: .scale(scale: 0.9)))
     }
 
@@ -290,7 +309,7 @@ struct ContainerCard: View {
                     }
                 }
             }
-            .padding(.leading, 50)
+            .padding(.leading, 40)
             .padding(.trailing, 2)
         }
     }
@@ -466,22 +485,30 @@ struct MeterView: View {
                 Text(label)
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(.secondary)
-                Spacer()
+                    .lineLimit(1)
+                    .fixedSize()
+                Spacer(minLength: 3)
+                // A fixed, right-aligned slot. Letting the caption size itself
+                // made the whole meter shuffle as soon as the number grew from
+                // "0%" to "100%" or from "18 MB" to "1,2 GB".
                 Text(caption ?? "—")
                     .font(.system(size: 9, weight: .medium).monospacedDigit())
                     .foregroundStyle(value == nil ? .tertiary : .secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .frame(width: 46, alignment: .trailing)
             }
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     Capsule().fill(.quaternary.opacity(0.7))
                     Capsule()
                         .fill(tint.gradient)
-                        .frame(width: max(2, geo.size.width * (value ?? 0)))
+                        .frame(width: max(2, geo.size.width * min(max(value ?? 0, 0), 1)))
                 }
             }
             .frame(height: 4)
         }
-        .frame(width: 74)
+        .frame(width: 83)
         .animation(.smooth(duration: 0.35), value: value)
     }
 }

--- a/ContainerGUI/Features/Containers/ContainersView.swift
+++ b/ContainerGUI/Features/Containers/ContainersView.swift
@@ -19,6 +19,7 @@ struct ContainersView: View {
     @State private var confirmation: ContainerConfirmation?
     /// Cards by default — the table stays one click away for dense scanning.
     @AppStorage("containerListStyle") private var listStyle: ContainerListStyle = .cards
+    @State private var search = ""
 
     enum ContainerConfirmation: Identifiable {
         case remove(ContainerInfo)
@@ -34,6 +35,22 @@ struct ContainersView: View {
     }
 
     private var store: ContainerStore { model.containers }
+
+    /// Containers matching the search field. Matches id, image, Compose project
+    /// and service, and the IP — the things you actually remember a container by.
+    private var filteredContainers: [ContainerInfo] {
+        let needle = search.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !needle.isEmpty else { return store.items }
+        return store.items.filter { container in
+            [
+                container.id,
+                container.imageReference,
+                container.composeProject ?? "",
+                container.composeService ?? "",
+                container.primaryIPv4Address ?? "",
+            ].contains { $0.lowercased().contains(needle) }
+        }
+    }
 
     /// Expand/collapse binding for a Compose project group, backed by the store
     /// (so it survives this view being recreated on sidebar navigation). Default
@@ -66,7 +83,7 @@ struct ContainersView: View {
         var projectMap: [String: [ContainerInfo]] = [:]
         var ungrouped: [ContainerInfo] = []
 
-        for container in store.items {
+        for container in filteredContainers {
             if let proj = container.composeProject {
                 projectMap[proj, default: []].append(container)
             } else {
@@ -110,6 +127,7 @@ struct ContainersView: View {
             }
         }
         .navigationTitle("Kontenery")
+        .searchable(text: $search, placement: .toolbar, prompt: Text("Szukaj kontenerów"))
         .task { await store.refresh() }
         .toolbar { toolbarContent }
         .sheet(isPresented: $showRunSheet) {
@@ -172,7 +190,14 @@ struct ContainersView: View {
 
     @ViewBuilder
     private var listSection: some View {
-        if store.items.isEmpty {
+        if !search.isEmpty && filteredContainers.isEmpty {
+            EmptyStateView(
+                symbol: "magnifyingglass",
+                title: String(localized: "Brak wyników"),
+                message: String(format: String(localized: "Żaden kontener nie pasuje do „%@”."), search),
+                tint: .secondary
+            )
+        } else if store.items.isEmpty {
             if model.system.serviceState.isRunning {
                 EmptyStateView(
                     symbol: "shippingbox",
@@ -188,6 +213,7 @@ struct ContainersView: View {
         } else if listStyle == .cards {
             ContainerCardsView(
                 selection: $selection,
+                containers: filteredContainers,
                 onRecreate: { recreateTarget = $0 },
                 onRemove: { confirmation = .remove($0) },
                 onRemoveProject: { confirmation = .removeProject($0, $1) }

--- a/ContainerGUI/Features/Helm/ChartSchema.swift
+++ b/ContainerGUI/Features/Helm/ChartSchema.swift
@@ -14,6 +14,10 @@ struct SchemaProperty: Hashable, Sendable {
     let description: String?
     let enumValues: [String]
     let isRequired: Bool
+    /// When the schema demands *one of* several keys (a top-level `oneOf`), the
+    /// full set of alternatives. Marking each of them a flat "required" would be
+    /// a lie: satisfying any one of them is enough.
+    let oneOfAlternatives: [String]
 
     var kind: ValuesField.Kind {
         switch type {
@@ -34,27 +38,57 @@ enum ChartSchema {
         guard let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { return [] }
         let defs = (root["$defs"] as? [String: Any]) ?? (root["definitions"] as? [String: Any]) ?? [:]
         var result: [SchemaProperty] = []
-        walk(root, path: [], required: requiredKeys(in: root), defs: defs, depth: 0, into: &result)
+        walk(root, path: [], requirements: requirements(in: root), defs: defs, depth: 0, into: &result)
         return result
     }
 
     /// Keys the schema insists on, including the branches of a `oneOf` — the
     /// Soneta chart expresses "either dblist or listaBazDanych" that way, and
     /// both are worth surfacing so the user can pick one.
-    private static func requiredKeys(in object: [String: Any]) -> Set<String> {
-        var keys = Set((object["required"] as? [String]) ?? [])
-        for branchKey in ["oneOf", "anyOf", "allOf"] {
-            for branch in (object[branchKey] as? [[String: Any]]) ?? [] {
-                keys.formUnion((branch["required"] as? [String]) ?? [])
+    private struct Requirements {
+        /// Demanded outright.
+        var always: Set<String> = []
+        /// key → the alternatives it competes with, itself included.
+        var oneOf: [String: [String]] = [:]
+
+        func alternatives(for key: String) -> [String] { oneOf[key] ?? [] }
+        func isRequired(_ key: String) -> Bool { always.contains(key) || oneOf[key] != nil }
+    }
+
+    private static func requirements(in object: [String: Any]) -> Requirements {
+        var result = Requirements()
+        result.always = Set((object["required"] as? [String]) ?? [])
+        // `allOf` branches all apply, so their keys are unconditionally required.
+        for branch in (object["allOf"] as? [[String: Any]]) ?? [] {
+            result.always.formUnion((branch["required"] as? [String]) ?? [])
+        }
+
+        // `oneOf`/`anyOf` express a choice. Keys common to every branch are
+        // required whichever branch you pick; the rest are alternatives.
+        for branchKey in ["oneOf", "anyOf"] {
+            let branches = (object[branchKey] as? [[String: Any]]) ?? []
+            guard branches.count > 1 else {
+                result.always.formUnion((branches.first?["required"] as? [String]) ?? [])
+                continue
+            }
+            let sets = branches.map { Set(($0["required"] as? [String]) ?? []) }
+            let common = sets.dropFirst().reduce(sets[0]) { $0.intersection($1) }
+            result.always.formUnion(common)
+
+            let choices = sets.map { $0.subtracting(common) }
+            let all = choices.reduce(into: Set<String>()) { $0.formUnion($1) }
+            let ordered = all.sorted()
+            for key in all where !result.always.contains(key) {
+                result.oneOf[key] = ordered
             }
         }
-        return keys
+        return result
     }
 
     private static func walk(
         _ object: [String: Any],
         path: [String],
-        required: Set<String>,
+        requirements: Requirements,
         defs: [String: Any],
         depth: Int,
         into result: inout [SchemaProperty]
@@ -77,7 +111,8 @@ enum ChartSchema {
                     type: type,
                     description: value["description"] as? String,
                     enumValues: (value["enum"] as? [Any])?.compactMap { $0 as? String } ?? [],
-                    isRequired: required.contains(key)
+                    isRequired: requirements.isRequired(key),
+                    oneOfAlternatives: requirements.alternatives(for: key)
                 )
             )
 
@@ -85,7 +120,8 @@ enum ChartSchema {
                 walk(
                     value,
                     path: childPath,
-                    required: requiredKeys(in: value),
+                    // `Self.` because the parameter shadows the function name.
+                    requirements: Self.requirements(in: value),
                     defs: defs,
                     depth: depth + 1,
                     into: &result
@@ -143,6 +179,7 @@ extension ChartValues {
                 defaultValue: field.defaultValue,
                 comment: field.comment ?? property.description,
                 isRequired: property.isRequired,
+                oneOfAlternatives: property.oneOfAlternatives,
                 enumValues: property.enumValues
             )
         }
@@ -152,8 +189,13 @@ extension ChartValues {
         let additions = schema
             .filter { !known.contains($0.path) }
             .filter { property in
-                // Only leaves; a bare object header with no value to type is noise.
-                property.type != "object" || property.isRequired
+                // Only leaves. An object whose children the form already lists
+                // (`image`, whose `image.tag` came from values.yaml) would
+                // otherwise appear a second time as an empty YAML box asking the
+                // user to retype what is already on screen.
+                guard property.type == "object" else { return true }
+                let prefix = property.path + "."
+                return !known.contains { $0.hasPrefix(prefix) } && !schema.contains { $0.path.hasPrefix(prefix) }
             }
             .sorted { lhs, rhs in
                 lhs.isRequired == rhs.isRequired ? lhs.path < rhs.path : lhs.isRequired
@@ -166,6 +208,7 @@ extension ChartValues {
                     defaultValue: "",
                     comment: property.description,
                     isRequired: property.isRequired,
+                    oneOfAlternatives: property.oneOfAlternatives,
                     enumValues: property.enumValues
                 )
             }

--- a/ContainerGUI/Features/Helm/ChartSchema.swift
+++ b/ContainerGUI/Features/Helm/ChartSchema.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/// Keys a chart declares in `values.schema.json` but does not ship in
+/// `values.yaml`.
+///
+/// This gap is not academic: the Soneta chart requires `dblist` (an XML string
+/// listing database connections) and it appears nowhere in `values.yaml`, so a
+/// form generated from defaults alone can never offer it — the install just
+/// fails schema validation with no field to fix. Reading the schema closes
+/// that, and brings descriptions, enums and required markers along with it.
+struct SchemaProperty: Hashable, Sendable {
+    let path: String
+    let type: String?
+    let description: String?
+    let enumValues: [String]
+    let isRequired: Bool
+
+    var kind: ValuesField.Kind {
+        switch type {
+        case "boolean": .boolean
+        case "integer", "number": .number
+        case "array": .stringList
+        case "object": .yaml
+        default: .string
+        }
+    }
+}
+
+enum ChartSchema {
+    /// Parses `values.schema.json`. Returns an empty list for anything it does
+    /// not understand — the form must degrade to the values.yaml-only version,
+    /// never break.
+    static func properties(fromSchema data: Data) -> [SchemaProperty] {
+        guard let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { return [] }
+        let defs = (root["$defs"] as? [String: Any]) ?? (root["definitions"] as? [String: Any]) ?? [:]
+        var result: [SchemaProperty] = []
+        walk(root, path: [], required: requiredKeys(in: root), defs: defs, depth: 0, into: &result)
+        return result
+    }
+
+    /// Keys the schema insists on, including the branches of a `oneOf` — the
+    /// Soneta chart expresses "either dblist or listaBazDanych" that way, and
+    /// both are worth surfacing so the user can pick one.
+    private static func requiredKeys(in object: [String: Any]) -> Set<String> {
+        var keys = Set((object["required"] as? [String]) ?? [])
+        for branchKey in ["oneOf", "anyOf", "allOf"] {
+            for branch in (object[branchKey] as? [[String: Any]]) ?? [] {
+                keys.formUnion((branch["required"] as? [String]) ?? [])
+            }
+        }
+        return keys
+    }
+
+    private static func walk(
+        _ object: [String: Any],
+        path: [String],
+        required: Set<String>,
+        defs: [String: Any],
+        depth: Int,
+        into result: inout [SchemaProperty]
+    ) {
+        // Charts nest deeply; past a few levels the generated rows stop being
+        // useful and the YAML tab is the better tool.
+        guard depth < 4 else { return }
+        guard let properties = object["properties"] as? [String: Any] else { return }
+
+        for (key, rawValue) in properties.sorted(by: { $0.key < $1.key }) {
+            guard var value = rawValue as? [String: Any] else { continue }
+            value = resolve(value, defs: defs)
+
+            let childPath = path + [key]
+            let type = typeName(of: value)
+
+            result.append(
+                SchemaProperty(
+                    path: childPath.joined(separator: "."),
+                    type: type,
+                    description: value["description"] as? String,
+                    enumValues: (value["enum"] as? [Any])?.compactMap { $0 as? String } ?? [],
+                    isRequired: required.contains(key)
+                )
+            )
+
+            if type == "object", value["properties"] != nil {
+                walk(
+                    value,
+                    path: childPath,
+                    required: requiredKeys(in: value),
+                    defs: defs,
+                    depth: depth + 1,
+                    into: &result
+                )
+            }
+        }
+    }
+
+    /// Follows a local `$ref` and flattens a single-branch `oneOf`, which is how
+    /// charts spell "string or number" (Kubernetes quantities).
+    private static func resolve(_ value: [String: Any], defs: [String: Any]) -> [String: Any] {
+        var value = value
+        if let ref = value["$ref"] as? String {
+            let name = String(ref.split(separator: "/").last ?? "")
+            if let target = defs[name] as? [String: Any] {
+                var merged = target
+                // Keep the local description — it is the more specific one.
+                if let description = value["description"] { merged["description"] = description }
+                value = merged
+            }
+        }
+        return value
+    }
+
+    private static func typeName(of value: [String: Any]) -> String? {
+        if let type = value["type"] as? String { return type }
+        if let types = value["type"] as? [String] {
+            return types.first { $0 != "null" } ?? types.first
+        }
+        // `oneOf: [{type: string}, {type: number}]` — take the first concrete one.
+        for branchKey in ["oneOf", "anyOf"] {
+            for branch in (value[branchKey] as? [[String: Any]]) ?? [] {
+                if let type = branch["type"] as? String, type != "null" { return type }
+            }
+        }
+        if value["properties"] != nil { return "object" }
+        return nil
+    }
+}
+
+extension ChartValues {
+    /// Folds schema knowledge into the fields taken from `values.yaml`:
+    /// annotates what is there, and appends what is declared but undefaulted.
+    static func merge(fields: [ValuesField], schema: [SchemaProperty]) -> [ValuesField] {
+        guard !schema.isEmpty else { return fields }
+        let byPath = Dictionary(schema.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
+        var known = Set(fields.map(\.path))
+
+        var merged = fields.map { field -> ValuesField in
+            guard let property = byPath[field.path] else { return field }
+            return ValuesField(
+                path: field.path,
+                components: field.components,
+                kind: field.kind,
+                defaultValue: field.defaultValue,
+                comment: field.comment ?? property.description,
+                isRequired: property.isRequired,
+                enumValues: property.enumValues
+            )
+        }
+
+        // Required-but-undefaulted keys go first: they are the ones blocking the
+        // install, and burying them at the bottom of the form hides the fix.
+        let additions = schema
+            .filter { !known.contains($0.path) }
+            .filter { property in
+                // Only leaves; a bare object header with no value to type is noise.
+                property.type != "object" || property.isRequired
+            }
+            .sorted { lhs, rhs in
+                lhs.isRequired == rhs.isRequired ? lhs.path < rhs.path : lhs.isRequired
+            }
+            .map { property in
+                ValuesField(
+                    path: property.path,
+                    components: property.path.split(separator: ".").map(String.init),
+                    kind: property.kind,
+                    defaultValue: "",
+                    comment: property.description,
+                    isRequired: property.isRequired,
+                    enumValues: property.enumValues
+                )
+            }
+
+        for addition in additions where !known.contains(addition.path) {
+            known.insert(addition.path)
+            merged.append(addition)
+        }
+        return merged
+    }
+}

--- a/ContainerGUI/Features/Helm/ChartValues.swift
+++ b/ContainerGUI/Features/Helm/ChartValues.swift
@@ -13,8 +13,11 @@ struct ValuesField: Identifiable, Hashable {
     /// Comment lines sitting directly above the key in `values.yaml`, or the
     /// schema's `description` for keys that only exist in the schema.
     let comment: String?
-    /// Declared in the schema's `required` (or one of its `oneOf` branches).
+    /// Declared in the schema's `required` (or common to every `oneOf` branch).
     var isRequired = false
+    /// Non-empty when the schema demands *one of* several keys and this is one
+    /// of them. Flagging each as plainly "required" would overstate it.
+    var oneOfAlternatives: [String] = []
     /// Schema `enum` — turns a free-text field into a picker.
     var enumValues: [String] = []
 

--- a/ContainerGUI/Features/Helm/ChartValues.swift
+++ b/ContainerGUI/Features/Helm/ChartValues.swift
@@ -22,8 +22,12 @@ struct ValuesField: Identifiable, Hashable {
         case boolean
         case number
         case string
-        /// Lists and anything else that is easier to edit as raw YAML.
-        case complex
+        /// A sequence of scalars (`imagePullSecrets: []`, `args: [--flag]`).
+        /// Gets a real row editor — charts are full of these.
+        case stringList
+        /// Sequences of objects, map-valued leaves, unresolved aliases: shapes a
+        /// row editor cannot represent, so they get a multi-line YAML box.
+        case yaml
     }
 }
 
@@ -53,7 +57,7 @@ enum ChartValues {
         switch node {
         case .mapping(let mapping) where !path.isEmpty && mapping.isEmpty:
             // An empty map is a value the user may want to fill in.
-            append(node, path: path, kind: .complex, comments: comments, into: &fields)
+            append(node, path: path, kind: .yaml, comments: comments, into: &fields)
 
         case .mapping(let mapping):
             for (keyNode, valueNode) in mapping {
@@ -61,8 +65,15 @@ enum ChartValues {
                 walk(valueNode, path: path + [key], comments: comments, into: &fields)
             }
 
-        case .sequence:
-            append(node, path: path, kind: .complex, comments: comments, into: &fields)
+        case .sequence(let sequence):
+            // An empty sequence is the overwhelmingly common case in charts
+            // (`imagePullSecrets: []`, `envs.web: []`) and is where the user
+            // most wants to add entries — treat it as a scalar list.
+            let isScalarList = sequence.allSatisfy { element in
+                if case .scalar = element { return true }
+                return false
+            }
+            append(node, path: path, kind: isScalarList ? .stringList : .yaml, comments: comments, into: &fields)
 
         case .scalar(let scalar):
             guard !path.isEmpty else { return }
@@ -74,7 +85,7 @@ enum ChartValues {
             // only catches an alias that could not be resolved (a dangling
             // anchor); show it as raw YAML instead of dropping the key.
             guard !path.isEmpty else { return }
-            append(node, path: path, kind: .complex, comments: comments, into: &fields)
+            append(node, path: path, kind: .yaml, comments: comments, into: &fields)
         }
     }
 
@@ -111,9 +122,46 @@ enum ChartValues {
             return ["null", "~"].contains(scalar.string) ? "" : scalar.string
         case .alias(let alias):
             return "*\(alias.anchor.rawValue)"
-        case .sequence, .mapping:
+        case .sequence(let sequence):
+            // Scalar lists round-trip in flow style (`["a", "b"]`) so the row
+            // editor and the stored edit are the same one-line string. Block
+            // style would reformat on every trip through the two editors.
+            let scalars: [String]? = sequence.reduce(into: [String]()) { result, element in
+                if case .scalar(let scalar) = element { result.append(scalar.string) }
+            }
+            if let scalars, scalars.count == sequence.count {
+                return flowList(scalars)
+            }
             let dumped = (try? Yams.serialize(node: node)) ?? ""
             return dumped.trimmingCharacters(in: .whitespacesAndNewlines)
+        case .mapping:
+            let dumped = (try? Yams.serialize(node: node)) ?? ""
+            return dumped.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    // MARK: - Scalar lists
+
+    /// `["a", "b"]` — JSON is valid YAML, so this parses straight back.
+    static func flowList(_ items: [String]) -> String {
+        guard !items.isEmpty else { return "[]" }
+        let encoded = items.map { item -> String in
+            let data = (try? JSONEncoder().encode(item)) ?? Data("\"\"".utf8)
+            return String(decoding: data, as: UTF8.self)
+        }
+        return "[" + encoded.joined(separator: ", ") + "]"
+    }
+
+    /// Reads a `.stringList` value back into rows for the editor.
+    static func listItems(_ text: String) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "[]" else { return [] }
+        guard let loaded = try? Yams.load(yaml: trimmed) else { return [] }
+        guard let array = loaded as? [Any] else { return [] }
+        return array.map { element in
+            if let string = element as? String { return string }
+            if let bool = element as? Bool { return bool ? "true" : "false" }
+            return String(describing: element)
         }
     }
 
@@ -204,7 +252,11 @@ enum ChartValues {
             // what charts branch on with `if .Values.x`.
             if text.isEmpty { return NSNull() }
             return text
-        case .complex:
+        case .stringList:
+            // An emptied list must stay a list — `null` would make a chart's
+            // `range .Values.args` fail rather than iterate nothing.
+            return listItems(text)
+        case .yaml:
             if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return NSNull() }
             return (try? Yams.load(yaml: text)) ?? text
         }

--- a/ContainerGUI/Features/Helm/ChartValues.swift
+++ b/ContainerGUI/Features/Helm/ChartValues.swift
@@ -8,10 +8,15 @@ struct ValuesField: Identifiable, Hashable {
     let path: String
     let components: [String]
     let kind: Kind
-    /// The chart's default, rendered as text (for `.complex`, as YAML).
+    /// The chart's default, rendered as text (for `.yaml`, as YAML).
     let defaultValue: String
-    /// Comment lines sitting directly above the key in `values.yaml`.
+    /// Comment lines sitting directly above the key in `values.yaml`, or the
+    /// schema's `description` for keys that only exist in the schema.
     let comment: String?
+    /// Declared in the schema's `required` (or one of its `oneOf` branches).
+    var isRequired = false
+    /// Schema `enum` — turns a free-text field into a picker.
+    var enumValues: [String] = []
 
     var id: String { path }
     var label: String { components.last ?? path }

--- a/ContainerGUI/Features/Helm/HelmStore.swift
+++ b/ContainerGUI/Features/Helm/HelmStore.swift
@@ -189,6 +189,47 @@ final class HelmStore {
         return try await helm.runRepo(args)
     }
 
+    /// The chart's `values.schema.json`, when it ships one.
+    ///
+    /// `helm show` has no schema subcommand, so the chart has to be unpacked.
+    /// It is a small tarball and helm caches the download; the result is cached
+    /// here per chart+version so switching versions back and forth is free.
+    /// Returns nil for charts without a schema — most of them.
+    func schema(of chart: String, version: String?) async -> [SchemaProperty] {
+        let key = "\(chart)@\(version ?? "latest")"
+        if let cached = schemaCache[key] { return cached }
+
+        let root = KubeconfigManager.directory
+            .deletingLastPathComponent()
+            .appending(path: "charts")
+        let destination = root.appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: destination) }
+
+        do {
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+            var args = ["pull", chart, "--untar", "--untardir", destination.path]
+            if let version, !version.isEmpty { args.append(contentsOf: ["--version", version]) }
+            try await helm.runRepo(args, timeout: .seconds(120))
+
+            let contents = try FileManager.default.contentsOfDirectory(at: destination, includingPropertiesForKeys: nil)
+            guard let chartDirectory = contents.first(where: { $0.hasDirectoryPath }) else { return [] }
+            let schemaURL = chartDirectory.appending(path: "values.schema.json")
+            guard let data = try? Data(contentsOf: schemaURL) else {
+                schemaCache[key] = []
+                return []
+            }
+            let properties = ChartSchema.properties(fromSchema: data)
+            schemaCache[key] = properties
+            return properties
+        } catch {
+            // A chart that cannot be pulled still gets the values.yaml form.
+            schemaCache[key] = []
+            return []
+        }
+    }
+
+    private var schemaCache: [String: [SchemaProperty]] = [:]
+
     // MARK: - Install / upgrade
 
     /// Renders the release without touching the cluster, so schema violations

--- a/ContainerGUI/Features/Helm/HelmView.swift
+++ b/ContainerGUI/Features/Helm/HelmView.swift
@@ -24,6 +24,7 @@ struct HelmView: View {
     @State private var historyTarget: HelmRelease?
     @State private var uninstallTarget: HelmRelease?
     @State private var search = ""
+    @State private var selectedRepository = ""
     @State private var newRepoName = ""
     @State private var newRepoURL = ""
 
@@ -218,11 +219,24 @@ struct HelmView: View {
 
     private var chartsTab: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 6) {
+            HStack(spacing: 8) {
+                // Picking a repository lists everything in it, which is how you
+                // browse when you don't already know a chart's name.
+                Picker("", selection: repositoryBinding) {
+                    Text("Wszystkie repozytoria").tag("")
+                    ForEach(store.repositories) { repository in
+                        Text(repository.name).tag(repository.name)
+                    }
+                }
+                .labelsHidden()
+                .frame(maxWidth: 190)
+
+                Divider().frame(height: 16)
+
                 Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
-                TextField("Szukaj chartów w repozytoriach…", text: $search)
+                TextField("Filtruj po nazwie…", text: $search)
                     .textFieldStyle(.plain)
-                    .onSubmit { Task { await store.search(search) } }
+                    .onSubmit { Task { await runSearch() } }
                 if store.isSearching { ProgressView().controlSize(.small) }
             }
             .padding(10)
@@ -232,7 +246,7 @@ struct HelmView: View {
                 EmptyStateView(
                     symbol: "square.stack.3d.up",
                     title: String(localized: "Znajdź chart"),
-                    message: String(localized: "Wpisz nazwę i naciśnij Enter. Przeszukiwane są repozytoria dodane w zakładce Repozytoria — odśwież je, jeśli wyniki wyglądają na nieaktualne."),
+                    message: String(localized: "Wybierz repozytorium, aby zobaczyć wszystkie jego charty, albo wpisz nazwę i naciśnij Enter. Przeszukiwane są repozytoria dodane w zakładce Repozytoria — odśwież je, jeśli wyniki wyglądają na nieaktualne."),
                     tint: .cyan
                 )
             } else {
@@ -266,6 +280,29 @@ struct HelmView: View {
                     }
                 }
             }
+        }
+    }
+
+    private var repositoryBinding: Binding<String> {
+        Binding(
+            get: { selectedRepository },
+            set: { name in
+                selectedRepository = name
+                Task { await runSearch() }
+            }
+        )
+    }
+
+    /// `helm search repo <name>/` returns every chart in that repository, which
+    /// is what makes the picker a browser rather than another filter.
+    private func runSearch() async {
+        let filter = search.trimmingCharacters(in: .whitespaces)
+        if selectedRepository.isEmpty {
+            await store.search(filter)
+        } else if filter.isEmpty {
+            await store.search("\(selectedRepository)/")
+        } else {
+            await store.search("\(selectedRepository)/\(filter)")
         }
     }
 

--- a/ContainerGUI/Features/Helm/InstallChartSheet.swift
+++ b/ContainerGUI/Features/Helm/InstallChartSheet.swift
@@ -38,8 +38,11 @@ struct InstallChartSheet: View {
     @State private var editor: Editor = .form
     @State private var filter = ""
     @State private var expandedGroups: Set<String> = []
+    /// String fields the user opened into a multi-line box.
+    @State private var expandedStrings: Set<String> = []
 
     @State private var isLoadingValues = true
+    @State private var isLoadingSchema = false
     @State private var isRunning = false
     @State private var finished = false
     @State private var validationError: String?
@@ -165,6 +168,14 @@ struct InstallChartSheet: View {
                     }
                 }
                 Spacer()
+                if isLoadingSchema {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("wczytuję schemat chartu…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 LoadFromFileButton(message: String(localized: "Wybierz plik values.yaml z nadpisaniami")) { contents in
                     overridesYAML = contents
                     editor = .yaml
@@ -243,7 +254,15 @@ struct InstallChartSheet: View {
                 Text(field.label)
                     .font(.callout)
                     .foregroundStyle(isEdited ? Color.accentColor : .primary)
-                if field.isRequired {
+                if !field.oneOfAlternatives.isEmpty {
+                    Text("jedno z")
+                        .font(.system(size: 9, weight: .semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.orange.opacity(0.14), in: Capsule())
+                        .foregroundStyle(Color.orange)
+                        .help(String(format: String(localized: "Chart wymaga dokładnie jednego z: %@"), field.oneOfAlternatives.joined(separator: ", ")))
+                } else if field.isRequired {
                     Text("wymagane")
                         .font(.system(size: 9, weight: .semibold))
                         .padding(.horizontal, 5)
@@ -262,7 +281,7 @@ struct InstallChartSheet: View {
                         edits[field.path] = contents
                     }
                 }
-                if field.kind.isInline {
+                if isInline(field) {
                     control(for: field)
                         .frame(width: 200, alignment: .trailing)
                 }
@@ -281,7 +300,7 @@ struct InstallChartSheet: View {
                 .accessibilityHidden(!isEdited)
                 .frame(width: 20)
             }
-            if !field.kind.isInline {
+            if !isInline(field) {
                 control(for: field)
                     .padding(.trailing, 26)
             }
@@ -304,7 +323,13 @@ struct InstallChartSheet: View {
                 ForEach(field.enumValues, id: \.self) { Text($0).tag($0) }
             }
             .labelsHidden()
-        case .number, .string:
+        case .string:
+            ExpandableTextField(
+                text: textBinding(field),
+                placeholder: field.defaultValue,
+                isExpanded: expansionBinding(forString: field)
+            )
+        case .number:
             TextField(field.defaultValue, text: textBinding(field), prompt: Text(field.defaultValue))
                 .textFieldStyle(.roundedBorder)
                 .font(.caption.monospaced())
@@ -383,6 +408,37 @@ struct InstallChartSheet: View {
             byGroup[field.group, default: []].append(field)
         }
         return order.map { FieldGroup(name: $0, fields: byGroup[$0] ?? []) }
+    }
+
+    /// A string field is inline while it is a one-liner; once expanded it
+    /// claims the full width of the pane on its own row.
+    private func isInline(_ field: ValuesField) -> Bool {
+        guard field.kind.isInline else { return false }
+        guard field.kind == .string else { return true }
+        return !isStringExpanded(field)
+    }
+
+    /// Auto-expands for content a single line cannot show, and for a required
+    /// key the chart never defaults — almost always a "paste the document here"
+    /// field, like the Soneta chart's XML database list.
+    private func isStringExpanded(_ field: ValuesField) -> Bool {
+        if expandedStrings.contains(field.path) { return true }
+        let value = edits[field.path] ?? field.defaultValue
+        if value.contains("\n") || value.count > 60 { return true }
+        return field.isRequired && field.defaultValue.isEmpty
+    }
+
+    private func expansionBinding(forString field: ValuesField) -> Binding<Bool> {
+        Binding(
+            get: { isStringExpanded(field) },
+            set: { expanded in
+                if expanded {
+                    expandedStrings.insert(field.path)
+                } else {
+                    expandedStrings.remove(field.path)
+                }
+            }
+        )
     }
 
     private func expansionBinding(for group: String) -> Binding<Bool> {
@@ -470,17 +526,28 @@ struct InstallChartSheet: View {
 
     private func reloadDefaults() async {
         isLoadingValues = true
-        defer { isLoadingValues = false }
+        defer { isLoadingValues = false; isLoadingSchema = false }
         do {
             let yaml = try await store.defaultValues(of: chart.name, version: version)
-            let parsed = try ChartValues.fields(from: yaml)
-            // Charts can require keys they do not default (the Soneta chart's
-            // `dblist`), so the schema is folded in — otherwise the form has no
-            // field for the very value blocking the install.
-            let schema = await store.schema(of: chart.name, version: version)
-            fields = ChartValues.merge(fields: parsed, schema: schema)
+            fields = try ChartValues.fields(from: yaml)
             // Open the first few groups so the pane isn't a wall of arrows.
             expandedGroups = Set(groupedFields.prefix(3).map(\.name))
+            isLoadingValues = false
+
+            // Charts can require keys they never default (the Soneta chart's
+            // `dblist`), and those only exist in values.schema.json — which helm
+            // has no command for, so the chart has to be unpacked. That is a
+            // download, so it happens *after* the form is already usable rather
+            // than holding it hostage; the extra fields appear when it lands.
+            let requestedVersion = version
+            isLoadingSchema = true
+            let schema = await store.schema(of: chart.name, version: requestedVersion)
+            // A version switch may have raced past this request.
+            guard requestedVersion == version else { return }
+            isLoadingSchema = false
+            guard !schema.isEmpty else { return }
+            fields = ChartValues.merge(fields: fields, schema: schema)
+            expandedGroups.formUnion(groupedFields.prefix(3).map(\.name))
         } catch {
             fields = []
             validationError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription

--- a/ContainerGUI/Features/Helm/InstallChartSheet.swift
+++ b/ContainerGUI/Features/Helm/InstallChartSheet.swift
@@ -165,6 +165,12 @@ struct InstallChartSheet: View {
                     }
                 }
                 Spacer()
+                LoadFromFileButton(message: String(localized: "Wybierz plik values.yaml z nadpisaniami")) { contents in
+                    overridesYAML = contents
+                    editor = .yaml
+                    validationError = ChartValues.validate(contents)
+                }
+                .help("Wczytaj cały plik values.yaml jako nadpisania")
                 if !edits.isEmpty {
                     Text(String(format: String(localized: "zmienione: %d"), edits.count))
                         .font(.caption)
@@ -237,10 +243,25 @@ struct InstallChartSheet: View {
                 Text(field.label)
                     .font(.callout)
                     .foregroundStyle(isEdited ? Color.accentColor : .primary)
+                if field.isRequired {
+                    Text("wymagane")
+                        .font(.system(size: 9, weight: .semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.orange.opacity(0.18), in: Capsule())
+                        .foregroundStyle(Color.orange)
+                }
                 if let comment = field.comment {
                     InfoTip(text: comment)
                 }
                 Spacer(minLength: 8)
+                // Whole-document values (an XML database list, a certificate)
+                // usually already exist as a file.
+                if field.kind == .string || field.kind == .yaml {
+                    LoadFromFileButton(message: String(format: String(localized: "Wybierz plik z wartością dla „%@”"), field.path)) { contents in
+                        edits[field.path] = contents
+                    }
+                }
                 if field.kind.isInline {
                     control(for: field)
                         .frame(width: 200, alignment: .trailing)
@@ -277,6 +298,12 @@ struct InstallChartSheet: View {
                 .labelsHidden()
                 .toggleStyle(.switch)
                 .controlSize(.mini)
+        case .number, .string where !field.enumValues.isEmpty:
+            Picker("", selection: textBinding(field)) {
+                if field.defaultValue.isEmpty { Text("—").tag("") }
+                ForEach(field.enumValues, id: \.self) { Text($0).tag($0) }
+            }
+            .labelsHidden()
         case .number, .string:
             TextField(field.defaultValue, text: textBinding(field), prompt: Text(field.defaultValue))
                 .textFieldStyle(.roundedBorder)
@@ -446,7 +473,12 @@ struct InstallChartSheet: View {
         defer { isLoadingValues = false }
         do {
             let yaml = try await store.defaultValues(of: chart.name, version: version)
-            fields = try ChartValues.fields(from: yaml)
+            let parsed = try ChartValues.fields(from: yaml)
+            // Charts can require keys they do not default (the Soneta chart's
+            // `dblist`), so the schema is folded in — otherwise the form has no
+            // field for the very value blocking the install.
+            let schema = await store.schema(of: chart.name, version: version)
+            fields = ChartValues.merge(fields: parsed, schema: schema)
             // Open the first few groups so the pane isn't a wall of arrows.
             expandedGroups = Set(groupedFields.prefix(3).map(\.name))
         } catch {

--- a/ContainerGUI/Features/Helm/InstallChartSheet.swift
+++ b/ContainerGUI/Features/Helm/InstallChartSheet.swift
@@ -232,7 +232,7 @@ struct InstallChartSheet: View {
     @ViewBuilder
     private func fieldRow(_ field: ValuesField) -> some View {
         let isEdited = edits[field.path] != nil
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 6) {
                 Text(field.label)
                     .font(.callout)
@@ -240,24 +240,29 @@ struct InstallChartSheet: View {
                 if let comment = field.comment {
                     InfoTip(text: comment)
                 }
-                Spacer()
-                control(for: field)
-                    .frame(maxWidth: 220)
-                if isEdited {
-                    Button("Przywróć", systemImage: "arrow.uturn.backward") {
-                        edits[field.path] = nil
-                    }
-                    .buttonStyle(.borderless)
-                    .labelStyle(.iconOnly)
-                    .controlSize(.small)
-                    .help("Przywróć wartość domyślną chartu")
+                Spacer(minLength: 8)
+                if field.kind.isInline {
+                    control(for: field)
+                        .frame(width: 200, alignment: .trailing)
                 }
+                // The reset button holds its slot whether or not it is visible.
+                // Letting it appear only once edited shifted every control
+                // leftwards the moment a switch was flipped.
+                Button("Przywróć", systemImage: "arrow.uturn.backward") {
+                    edits[field.path] = nil
+                }
+                .buttonStyle(.borderless)
+                .labelStyle(.iconOnly)
+                .controlSize(.small)
+                .help("Przywróć wartość domyślną chartu")
+                .opacity(isEdited ? 1 : 0)
+                .disabled(!isEdited)
+                .accessibilityHidden(!isEdited)
+                .frame(width: 20)
             }
-            if field.kind == .complex {
-                Text(field.defaultValue.isEmpty ? "—" : field.defaultValue)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.secondary)
-                    .lineLimit(3)
+            if !field.kind.isInline {
+                control(for: field)
+                    .padding(.trailing, 26)
             }
         }
         .padding(.leading, 14)
@@ -276,10 +281,10 @@ struct InstallChartSheet: View {
             TextField(field.defaultValue, text: textBinding(field), prompt: Text(field.defaultValue))
                 .textFieldStyle(.roundedBorder)
                 .font(.caption.monospaced())
-        case .complex:
-            TextField(String(localized: "YAML"), text: textBinding(field), prompt: Text(verbatim: "[]"))
-                .textFieldStyle(.roundedBorder)
-                .font(.caption.monospaced())
+        case .stringList:
+            ValuesListEditor(items: listBinding(field))
+        case .yaml:
+            ValuesYAMLEditor(text: textBinding(field), placeholder: field.defaultValue)
         }
     }
 
@@ -370,6 +375,23 @@ struct InstallChartSheet: View {
                     edits[field.path] = nil
                 } else {
                     edits[field.path] = newValue
+                }
+            }
+        )
+    }
+
+    /// Rows for a `.stringList` field. The edit itself stays a single flow-style
+    /// string (`["a", "b"]`) so the YAML tab and the form remain one source of
+    /// truth; this only presents it as rows.
+    private func listBinding(_ field: ValuesField) -> Binding<[String]> {
+        Binding(
+            get: { ChartValues.listItems(edits[field.path] ?? field.defaultValue) },
+            set: { items in
+                let encoded = ChartValues.flowList(items)
+                if encoded == field.defaultValue {
+                    edits[field.path] = nil
+                } else {
+                    edits[field.path] = encoded
                 }
             }
         )

--- a/ContainerGUI/Features/Helm/ValuesFieldEditors.swift
+++ b/ContainerGUI/Features/Helm/ValuesFieldEditors.swift
@@ -1,4 +1,34 @@
 import SwiftUI
+import AppKit
+
+/// Loads a value from a file on disk.
+///
+/// Some chart values are whole documents — the Soneta chart's `dblist` is an
+/// XML block listing database connections. Pasting one into a text field is
+/// miserable, and it is exactly the thing that already exists as a file.
+struct LoadFromFileButton: View {
+    let message: String
+    let onLoad: (String) -> Void
+
+    var body: some View {
+        Button("Wczytaj z pliku…", systemImage: "folder") {
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = true
+            panel.canChooseDirectories = false
+            panel.allowsMultipleSelection = false
+            panel.message = message
+            guard panel.runModal() == .OK,
+                  let url = panel.url,
+                  let contents = try? String(contentsOf: url, encoding: .utf8)
+            else { return }
+            onLoad(contents.trimmingCharacters(in: .newlines))
+        }
+        .buttonStyle(.borderless)
+        .labelStyle(.iconOnly)
+        .controlSize(.small)
+        .help("Wczytaj wartość z pliku na dysku")
+    }
+}
 
 extension ValuesField.Kind {
     /// Whether the control fits on the same line as the key's label. Lists and

--- a/ContainerGUI/Features/Helm/ValuesFieldEditors.swift
+++ b/ContainerGUI/Features/Helm/ValuesFieldEditors.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+extension ValuesField.Kind {
+    /// Whether the control fits on the same line as the key's label. Lists and
+    /// YAML blocks need the full width of the pane, so they drop to their own
+    /// row underneath.
+    var isInline: Bool {
+        switch self {
+        case .boolean, .number, .string: true
+        case .stringList, .yaml: false
+        }
+    }
+}
+
+/// Row editor for a list of scalars — `imagePullSecrets`, `args`, `tolerations`
+/// and the many `envs.<component>: []` keys charts are full of.
+///
+/// A single-line text field holding `["a","b"]` technically worked, but it made
+/// the most common edit in a chart (adding one entry to an empty list) an
+/// exercise in YAML punctuation.
+struct ValuesListEditor: View {
+    @Binding var items: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            ForEach(items.indices, id: \.self) { index in
+                HStack(spacing: 5) {
+                    Image(systemName: "line.3.horizontal")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                    TextField(
+                        String(localized: "wartość"),
+                        text: Binding(
+                            get: { index < items.count ? items[index] : "" },
+                            set: { if index < items.count { items[index] = $0 } }
+                        )
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption.monospaced())
+                    Button("Usuń", systemImage: "minus.circle.fill") {
+                        guard index < items.count else { return }
+                        items.remove(at: index)
+                    }
+                    .buttonStyle(.borderless)
+                    .labelStyle(.iconOnly)
+                    .controlSize(.small)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            Button("Dodaj pozycję", systemImage: "plus.circle") {
+                items.append("")
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .font(.caption)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// Multi-line YAML box for values a row editor cannot represent: maps and lists
+/// of objects (`volumes`, `resources`, an aliased block).
+struct ValuesYAMLEditor: View {
+    @Binding var text: String
+    let placeholder: String
+
+    @State private var isExpanded = false
+
+    private var lineCount: Int {
+        max(1, text.split(separator: "\n", omittingEmptySubsequences: false).count)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if isExpanded || !text.isEmpty {
+                TextEditor(text: $text)
+                    .font(.caption.monospaced())
+                    .frame(height: CGFloat(min(max(lineCount, 3), 12)) * 15 + 10)
+                    .scrollContentBackground(.hidden)
+                    .padding(4)
+                    .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 6))
+                    .overlay(alignment: .topLeading) {
+                        if text.isEmpty {
+                            Text(placeholder.isEmpty ? "klucz: wartość" : placeholder)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.tertiary)
+                                .padding(.horizontal, 9)
+                                .padding(.vertical, 8)
+                                .allowsHitTesting(false)
+                        }
+                    }
+            } else {
+                HStack(spacing: 6) {
+                    Text(placeholder.isEmpty ? "—" : placeholder)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    Spacer()
+                    Button("Edytuj YAML", systemImage: "pencil") { isExpanded = true }
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .font(.caption)
+                }
+            }
+        }
+    }
+}

--- a/ContainerGUI/Features/Helm/ValuesFieldEditors.swift
+++ b/ContainerGUI/Features/Helm/ValuesFieldEditors.swift
@@ -42,6 +42,74 @@ extension ValuesField.Kind {
     }
 }
 
+/// Single-line by default, expandable to a real text box.
+///
+/// Some string values are documents — an XML database list, a certificate, an
+/// appsettings blob. One line is fine for a tag or a hostname and useless for
+/// those, so the field grows: automatically once the value has line breaks or
+/// runs long, and on demand via the expand button.
+struct ExpandableTextField: View {
+    @Binding var text: String
+    let placeholder: String
+    /// Owned by the row, which needs to know too: an expanded editor takes the
+    /// full width of the pane instead of the inline control slot.
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        Group {
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 2) {
+                    TextEditor(text: $text)
+                        .font(.caption.monospaced())
+                        .frame(minHeight: 78, maxHeight: 190)
+                        .scrollContentBackground(.hidden)
+                        .padding(4)
+                        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 6))
+                        .overlay(alignment: .topLeading) {
+                            if text.isEmpty {
+                                Text(placeholder)
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.horizontal, 9)
+                                    .padding(.vertical, 8)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                    HStack(spacing: 6) {
+                        Spacer()
+                        if !text.isEmpty {
+                            Text(String(format: String(localized: "%lld znaków"), Int64(text.count)))
+                                .font(.system(size: 9).monospacedDigit())
+                                .foregroundStyle(.tertiary)
+                        }
+                        Button("Zwiń", systemImage: "arrow.down.right.and.arrow.up.left") {
+                            isExpanded = false
+                        }
+                        .buttonStyle(.borderless)
+                        .labelStyle(.iconOnly)
+                        .controlSize(.small)
+                        .disabled(text.contains("\n"))
+                        .help("Zwiń pole")
+                    }
+                }
+            } else {
+                HStack(spacing: 4) {
+                    TextField(placeholder, text: $text, prompt: Text(placeholder))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.caption.monospaced())
+                    Button("Rozwiń", systemImage: "arrow.up.left.and.arrow.down.right") {
+                        isExpanded = true
+                    }
+                    .buttonStyle(.borderless)
+                    .labelStyle(.iconOnly)
+                    .controlSize(.small)
+                    .help("Rozwiń do pola wielolinijkowego")
+                }
+            }
+        }
+    }
+}
+
 /// Row editor for a list of scalars — `imagePullSecrets`, `args`, `tolerations`
 /// and the many `envs.<component>: []` keys charts are full of.
 ///

--- a/ContainerGUI/Features/Kubernetes/ClusterDetailView.swift
+++ b/ContainerGUI/Features/Kubernetes/ClusterDetailView.swift
@@ -1,0 +1,276 @@
+import SwiftUI
+import AppKit
+
+/// What a cluster actually is, once you click it: its nodes, how to reach it,
+/// what is deployed on it, and the copy-pasteable commands to work with it.
+///
+/// Selecting a card previously did nothing, which reads as a broken control
+/// rather than a deliberate absence.
+struct ClusterDetailView: View {
+    @Environment(AppModel.self) private var model
+
+    let cluster: K8sCluster
+
+    @State private var tab: Tab = .overview
+    @State private var releases: [HelmRelease] = []
+    @State private var isLoadingReleases = false
+
+    enum Tab: String, CaseIterable, Identifiable {
+        case overview, nodes, access
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .overview: String(localized: "Przegląd")
+            case .nodes: String(localized: "Węzły")
+            case .access: String(localized: "Dostęp")
+            }
+        }
+    }
+
+    private var kubeconfigPath: String { KubeconfigManager.path(for: cluster.name) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Picker("", selection: $tab) {
+                ForEach(Tab.allCases) { Text($0.title).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            Divider()
+
+            switch tab {
+            case .overview: overview
+            case .nodes: nodes
+            case .access: access
+            }
+        }
+        .task(id: cluster.id) { await loadReleases() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "helm")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 28, height: 28)
+                .background(Color.cyan.gradient, in: RoundedRectangle(cornerRadius: 7))
+            VStack(alignment: .leading, spacing: 1) {
+                Text(cluster.name).font(.headline)
+                Text(cluster.isRunning ? String(localized: "Klaster działa") : String(localized: "Klaster zatrzymany"))
+                    .font(.caption)
+                    .foregroundStyle(cluster.isRunning ? Color.green : .secondary)
+            }
+            Spacer()
+            if cluster.isRunning {
+                Button("Wdrożenia Helm", systemImage: "shippingbox") {
+                    model.selection = .helm
+                    Task { await model.helm.select(cluster: cluster.name) }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Overview
+
+    private var overview: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                factGrid
+                releasesSection
+            }
+            .padding(12)
+        }
+    }
+
+    private var factGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
+            fact(String(localized: "Węzły"), "\(cluster.nodes.count)", "circle.grid.2x2")
+            fact(String(localized: "Rdzenie"), cluster.controlPlane?.cpus ?? "—", "cpu")
+            fact(String(localized: "Pamięć"), cluster.controlPlane?.memory ?? "—", "memorychip")
+            fact(String(localized: "Adres"), cluster.controlPlane?.address ?? "—", "network")
+            if let port = cluster.controlPlane?.apiServerHostPort {
+                fact(String(localized: "API serwera"), "localhost:\(port)", "point.3.connected.trianglepath.dotted")
+            }
+            fact(
+                String(localized: "Wdrożenia"),
+                isLoadingReleases ? "…" : "\(releases.count)",
+                "shippingbox"
+            )
+        }
+    }
+
+    private func fact(_ title: String, _ value: String, _ symbol: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                Image(systemName: symbol)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.cyan)
+                Text(title)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Text(value)
+                .font(.system(size: 13, weight: .medium).monospacedDigit())
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 9))
+    }
+
+    @ViewBuilder
+    private var releasesSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 5) {
+                Image(systemName: "shippingbox.fill").foregroundStyle(Color.mint.gradient)
+                Text("Wdrożenia Helm").font(.subheadline.weight(.semibold))
+                Spacer()
+                if isLoadingReleases { ProgressView().controlSize(.small) }
+            }
+            if !HelmCLI.isInstalled {
+                Text("Zainstaluj helm (brew install helm), aby zobaczyć wdrożenia.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if !cluster.isRunning {
+                Text("Uruchom klaster, aby zobaczyć wdrożenia.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if releases.isEmpty && !isLoadingReleases {
+                Text("Brak wdrożeń w tym klastrze.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(releases) { release in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(release.isDeployed ? Color.green : Color.orange)
+                            .frame(width: 6, height: 6)
+                        Text(release.name).font(.callout)
+                        Text(release.chart)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(release.namespace)
+                            .font(.caption2)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(.quaternary.opacity(0.6), in: Capsule())
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+        .padding(10)
+        .background(.quaternary.opacity(0.25), in: RoundedRectangle(cornerRadius: 9))
+    }
+
+    // MARK: - Nodes
+
+    private var nodes: some View {
+        ScrollView {
+            VStack(spacing: 6) {
+                ForEach(cluster.nodes) { node in
+                    HStack(spacing: 10) {
+                        StatusDot(state: node.state)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(node.name).font(.callout.weight(.medium))
+                            Text(node.role).font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(node.cpus.isEmpty ? "—" : "\(node.cpus) CPU")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                        Text(node.memory)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                        Text(node.address.isEmpty ? "—" : node.address)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                    .padding(10)
+                    .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 9))
+                }
+            }
+            .padding(12)
+        }
+    }
+
+    // MARK: - Access
+
+    private var access: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Aplikacja używa własnego pliku kubeconfig dla tego klastra i nie modyfikuje Twojego ~/.kube/config.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                commandRow(String(localized: "Plik kubeconfig aplikacji"), kubeconfigPath)
+                commandRow(String(localized: "Pody"), "kubectl --kubeconfig \(kubeconfigPath) --context \(cluster.name) get pods -A")
+                commandRow(String(localized: "Wdrożenia Helm"), "helm --kubeconfig \(kubeconfigPath) --kube-context \(cluster.name) list -A")
+                if let port = cluster.controlPlane?.apiServerHostPort {
+                    commandRow(String(localized: "Adres API"), "https://127.0.0.1:\(port)")
+                }
+            }
+            .padding(12)
+        }
+    }
+
+    private func commandRow(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text(value)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+                Spacer()
+                Button("Kopiuj", systemImage: "doc.on.doc") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(value, forType: .string)
+                }
+                .buttonStyle(.borderless)
+                .labelStyle(.iconOnly)
+                .controlSize(.small)
+            }
+        }
+        .padding(10)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 9))
+    }
+
+    // MARK: - Data
+
+    private func loadReleases() async {
+        guard cluster.isRunning, HelmCLI.isInstalled else {
+            releases = []
+            return
+        }
+        isLoadingReleases = true
+        defer { isLoadingReleases = false }
+        guard let target = try? await KubeconfigManager.target(for: cluster.name) else {
+            releases = []
+            return
+        }
+        releases = (try? await HelmCLI.shared.json(
+            ["list", "--all-namespaces"],
+            on: target,
+            as: [HelmRelease].self
+        )) ?? []
+    }
+}

--- a/ContainerGUI/Features/Kubernetes/KubernetesView.swift
+++ b/ContainerGUI/Features/Kubernetes/KubernetesView.swift
@@ -6,6 +6,7 @@ struct KubernetesView: View {
     @Environment(AppModel.self) private var model
 
     @State private var showCreate = false
+    @State private var selection: String?
     @State private var loadImageTarget: K8sCluster?
     @State private var deleteTarget: K8sCluster?
 
@@ -54,7 +55,27 @@ struct KubernetesView: View {
 
     // MARK: - Cluster list
 
+    private var selectedCluster: K8sCluster? {
+        selection.flatMap { id in store.clusters.first { $0.id == id } }
+    }
+
     private var clusterList: some View {
+        GeometryReader { geo in
+            VSplitView {
+                clusterScroll
+                    .frame(
+                        minHeight: 120,
+                        maxHeight: selectedCluster == nil ? .infinity : max(geo.size.height * 0.45, 120)
+                    )
+                if let cluster = selectedCluster {
+                    ClusterDetailView(cluster: cluster)
+                        .frame(minHeight: 260, maxHeight: .infinity)
+                }
+            }
+        }
+    }
+
+    private var clusterScroll: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
                 if let error = store.error {
@@ -122,7 +143,17 @@ struct KubernetesView: View {
             }
         }
         .padding(12)
-        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10))
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(selection == cluster.id ? AnyShapeStyle(Color.accentColor.opacity(0.12)) : AnyShapeStyle(.quaternary.opacity(0.4)))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(selection == cluster.id ? Color.accentColor.opacity(0.55) : .clear, lineWidth: 1.5)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 10))
+        .onTapGesture { selection = selection == cluster.id ? nil : cluster.id }
+        .animation(.smooth(duration: 0.18), value: selection)
     }
 
     private func nodeSummary(_ node: K8sNode) -> String {

--- a/ContainerGUI/Resources/en.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/en.lproj/Localizable.strings
@@ -645,3 +645,11 @@
 "Pody" = "Pods";
 "Adres API" = "API address";
 "Kopiuj" = "Copy";
+
+/* Values from a file, schema-required keys */
+"Wczytaj z pliku…" = "Load from file…";
+"Wczytaj wartość z pliku na dysku" = "Load the value from a file on disk";
+"Wybierz plik z wartością dla „%@”" = "Choose a file with the value for “%@”";
+"Wybierz plik values.yaml z nadpisaniami" = "Choose a values.yaml file with overrides";
+"Wczytaj cały plik values.yaml jako nadpisania" = "Load a whole values.yaml as the overrides";
+"wymagane" = "required";

--- a/ContainerGUI/Resources/en.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/en.lproj/Localizable.strings
@@ -619,3 +619,29 @@
 "Karty" = "Cards";
 "Tabela" = "Table";
 "Przełącz między kartami a tabelą" = "Switch between cards and table";
+
+/* Search, values list editor, cluster detail */
+"Szukaj kontenerów" = "Search containers";
+"Brak wyników" = "No results";
+"Żaden kontener nie pasuje do „%@”." = "No container matches “%@”.";
+"Wszystkie repozytoria" = "All repositories";
+"Filtruj po nazwie…" = "Filter by name…";
+"Wybierz repozytorium, aby zobaczyć wszystkie jego charty, albo wpisz nazwę i naciśnij Enter. Przeszukiwane są repozytoria dodane w zakładce Repozytoria — odśwież je, jeśli wyniki wyglądają na nieaktualne." = "Pick a repository to list every chart in it, or type a name and press Enter. The repositories added on the Repositories tab are searched — refresh them if the results look stale.";
+"Dodaj pozycję" = "Add item";
+"Edytuj YAML" = "Edit YAML";
+"Węzły" = "Nodes";
+"Dostęp" = "Access";
+"Klaster działa" = "Cluster running";
+"Klaster zatrzymany" = "Cluster stopped";
+"Wdrożenia Helm" = "Helm releases";
+"Rdzenie" = "Cores";
+"Adres" = "Address";
+"API serwera" = "API server";
+"Zainstaluj helm (brew install helm), aby zobaczyć wdrożenia." = "Install helm (brew install helm) to see releases.";
+"Uruchom klaster, aby zobaczyć wdrożenia." = "Start the cluster to see its releases.";
+"Brak wdrożeń w tym klastrze." = "No releases in this cluster.";
+"Aplikacja używa własnego pliku kubeconfig dla tego klastra i nie modyfikuje Twojego ~/.kube/config." = "The app uses its own kubeconfig for this cluster and never modifies your ~/.kube/config.";
+"Plik kubeconfig aplikacji" = "The app's kubeconfig file";
+"Pody" = "Pods";
+"Adres API" = "API address";
+"Kopiuj" = "Copy";

--- a/ContainerGUI/Resources/en.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/en.lproj/Localizable.strings
@@ -653,3 +653,13 @@
 "Wybierz plik values.yaml z nadpisaniami" = "Choose a values.yaml file with overrides";
 "Wczytaj cały plik values.yaml jako nadpisania" = "Load a whole values.yaml as the overrides";
 "wymagane" = "required";
+
+/* One-of requirements, expandable fields, background schema load */
+"jedno z" = "one of";
+"Chart wymaga dokładnie jednego z: %@" = "The chart requires exactly one of: %@";
+"Rozwiń" = "Expand";
+"Zwiń" = "Collapse";
+"Rozwiń do pola wielolinijkowego" = "Expand into a multi-line box";
+"Zwiń pole" = "Collapse the field";
+"%lld znaków" = "%lld characters";
+"wczytuję schemat chartu…" = "loading the chart's schema…";

--- a/ContainerGUI/Resources/pl.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/pl.lproj/Localizable.strings
@@ -653,3 +653,13 @@
 "Wybierz plik values.yaml z nadpisaniami" = "Wybierz plik values.yaml z nadpisaniami";
 "Wczytaj cały plik values.yaml jako nadpisania" = "Wczytaj cały plik values.yaml jako nadpisania";
 "wymagane" = "wymagane";
+
+/* One-of requirements, expandable fields, background schema load */
+"jedno z" = "jedno z";
+"Chart wymaga dokładnie jednego z: %@" = "Chart wymaga dokładnie jednego z: %@";
+"Rozwiń" = "Rozwiń";
+"Zwiń" = "Zwiń";
+"Rozwiń do pola wielolinijkowego" = "Rozwiń do pola wielolinijkowego";
+"Zwiń pole" = "Zwiń pole";
+"%lld znaków" = "%lld znaków";
+"wczytuję schemat chartu…" = "wczytuję schemat chartu…";

--- a/ContainerGUI/Resources/pl.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/pl.lproj/Localizable.strings
@@ -619,3 +619,29 @@
 "Karty" = "Karty";
 "Tabela" = "Tabela";
 "Przełącz między kartami a tabelą" = "Przełącz między kartami a tabelą";
+
+/* Search, values list editor, cluster detail */
+"Szukaj kontenerów" = "Szukaj kontenerów";
+"Brak wyników" = "Brak wyników";
+"Żaden kontener nie pasuje do „%@”." = "Żaden kontener nie pasuje do „%@”.";
+"Wszystkie repozytoria" = "Wszystkie repozytoria";
+"Filtruj po nazwie…" = "Filtruj po nazwie…";
+"Wybierz repozytorium, aby zobaczyć wszystkie jego charty, albo wpisz nazwę i naciśnij Enter. Przeszukiwane są repozytoria dodane w zakładce Repozytoria — odśwież je, jeśli wyniki wyglądają na nieaktualne." = "Wybierz repozytorium, aby zobaczyć wszystkie jego charty, albo wpisz nazwę i naciśnij Enter. Przeszukiwane są repozytoria dodane w zakładce Repozytoria — odśwież je, jeśli wyniki wyglądają na nieaktualne.";
+"Dodaj pozycję" = "Dodaj pozycję";
+"Edytuj YAML" = "Edytuj YAML";
+"Węzły" = "Węzły";
+"Dostęp" = "Dostęp";
+"Klaster działa" = "Klaster działa";
+"Klaster zatrzymany" = "Klaster zatrzymany";
+"Wdrożenia Helm" = "Wdrożenia Helm";
+"Rdzenie" = "Rdzenie";
+"Adres" = "Adres";
+"API serwera" = "API serwera";
+"Zainstaluj helm (brew install helm), aby zobaczyć wdrożenia." = "Zainstaluj helm (brew install helm), aby zobaczyć wdrożenia.";
+"Uruchom klaster, aby zobaczyć wdrożenia." = "Uruchom klaster, aby zobaczyć wdrożenia.";
+"Brak wdrożeń w tym klastrze." = "Brak wdrożeń w tym klastrze.";
+"Aplikacja używa własnego pliku kubeconfig dla tego klastra i nie modyfikuje Twojego ~/.kube/config." = "Aplikacja używa własnego pliku kubeconfig dla tego klastra i nie modyfikuje Twojego ~/.kube/config.";
+"Plik kubeconfig aplikacji" = "Plik kubeconfig aplikacji";
+"Pody" = "Pody";
+"Adres API" = "Adres API";
+"Kopiuj" = "Kopiuj";

--- a/ContainerGUI/Resources/pl.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/pl.lproj/Localizable.strings
@@ -645,3 +645,11 @@
 "Pody" = "Pody";
 "Adres API" = "Adres API";
 "Kopiuj" = "Kopiuj";
+
+/* Values from a file, schema-required keys */
+"Wczytaj z pliku…" = "Wczytaj z pliku…";
+"Wczytaj wartość z pliku na dysku" = "Wczytaj wartość z pliku na dysku";
+"Wybierz plik z wartością dla „%@”" = "Wybierz plik z wartością dla „%@”";
+"Wybierz plik values.yaml z nadpisaniami" = "Wybierz plik values.yaml z nadpisaniami";
+"Wczytaj cały plik values.yaml jako nadpisania" = "Wczytaj cały plik values.yaml jako nadpisania";
+"wymagane" = "wymagane";

--- a/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -645,3 +645,11 @@
 "Pody" = "Pod";
 "Adres API" = "API 地址";
 "Kopiuj" = "复制";
+
+/* Values from a file, schema-required keys */
+"Wczytaj z pliku…" = "从文件载入…";
+"Wczytaj wartość z pliku na dysku" = "从磁盘上的文件载入该值";
+"Wybierz plik z wartością dla „%@”" = "为“%@”选择包含值的文件";
+"Wybierz plik values.yaml z nadpisaniami" = "选择包含覆盖项的 values.yaml 文件";
+"Wczytaj cały plik values.yaml jako nadpisania" = "将整个 values.yaml 作为覆盖项载入";
+"wymagane" = "必填";

--- a/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -619,3 +619,29 @@
 "Karty" = "卡片";
 "Tabela" = "表格";
 "Przełącz między kartami a tabelą" = "在卡片与表格之间切换";
+
+/* Search, values list editor, cluster detail */
+"Szukaj kontenerów" = "搜索容器";
+"Brak wyników" = "没有结果";
+"Żaden kontener nie pasuje do „%@”." = "没有容器匹配“%@”。";
+"Wszystkie repozytoria" = "所有仓库";
+"Filtruj po nazwie…" = "按名称筛选…";
+"Wybierz repozytorium, aby zobaczyć wszystkie jego charty, albo wpisz nazwę i naciśnij Enter. Przeszukiwane są repozytoria dodane w zakładce Repozytoria — odśwież je, jeśli wyniki wyglądają na nieaktualne." = "选择一个仓库以列出其中所有 chart，或输入名称并按回车。搜索范围是“仓库”标签页中添加的仓库——若结果看起来过时，请刷新它们。";
+"Dodaj pozycję" = "添加条目";
+"Edytuj YAML" = "编辑 YAML";
+"Węzły" = "节点";
+"Dostęp" = "访问";
+"Klaster działa" = "集群运行中";
+"Klaster zatrzymany" = "集群已停止";
+"Wdrożenia Helm" = "Helm 发布";
+"Rdzenie" = "核心数";
+"Adres" = "地址";
+"API serwera" = "API 服务器";
+"Zainstaluj helm (brew install helm), aby zobaczyć wdrożenia." = "安装 helm（brew install helm）以查看发布。";
+"Uruchom klaster, aby zobaczyć wdrożenia." = "启动集群以查看其发布。";
+"Brak wdrożeń w tym klastrze." = "此集群中没有发布。";
+"Aplikacja używa własnego pliku kubeconfig dla tego klastra i nie modyfikuje Twojego ~/.kube/config." = "应用为此集群使用自己的 kubeconfig，绝不修改你的 ~/.kube/config。";
+"Plik kubeconfig aplikacji" = "应用的 kubeconfig 文件";
+"Pody" = "Pod";
+"Adres API" = "API 地址";
+"Kopiuj" = "复制";

--- a/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ContainerGUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -653,3 +653,13 @@
 "Wybierz plik values.yaml z nadpisaniami" = "选择包含覆盖项的 values.yaml 文件";
 "Wczytaj cały plik values.yaml jako nadpisania" = "将整个 values.yaml 作为覆盖项载入";
 "wymagane" = "必填";
+
+/* One-of requirements, expandable fields, background schema load */
+"jedno z" = "二选一";
+"Chart wymaga dokładnie jednego z: %@" = "该 chart 需要且仅需其中之一：%@";
+"Rozwiń" = "展开";
+"Zwiń" = "收起";
+"Rozwiń do pola wielolinijkowego" = "展开为多行文本框";
+"Zwiń pole" = "收起字段";
+"%lld znaków" = "%lld 个字符";
+"wczytuję schemat chartu…" = "正在载入 chart 架构…";

--- a/ContainerGUITests/ChartSchemaTests.swift
+++ b/ContainerGUITests/ChartSchemaTests.swift
@@ -12,19 +12,39 @@ final class ChartSchemaTests: XCTestCase {
         return try Data(contentsOf: try XCTUnwrap(url, "Brak fixtury schematu"))
     }
 
-    func testFindsKeysRequiredThroughOneOfBranches() throws {
+    /// The chart spells "image, plus either dblist or listaBazDanych" as a
+    /// top-level `oneOf`. Badging all three a flat "required" overstates it —
+    /// only `image` is unconditional; the other two are alternatives.
+    func testSeparatesUnconditionalRequirementsFromOneOfAlternatives() throws {
         let properties = ChartSchema.properties(fromSchema: try schemaFixture())
         let byPath = Dictionary(properties.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
 
-        // The chart spells "either dblist or listaBazDanych" as a top-level
-        // oneOf; both must surface or the user cannot satisfy either branch.
-        XCTAssertEqual(byPath["dblist"]?.isRequired, true)
-        XCTAssertEqual(byPath["listaBazDanych"]?.isRequired, true)
+        // Present in every branch → genuinely required, with no alternatives.
         XCTAssertEqual(byPath["image"]?.isRequired, true)
+        XCTAssertEqual(byPath["image"]?.oneOfAlternatives, [])
+
+        // One of these two, not both.
+        XCTAssertEqual(byPath["dblist"]?.oneOfAlternatives, ["dblist", "listaBazDanych"])
+        XCTAssertEqual(byPath["listaBazDanych"]?.oneOfAlternatives, ["dblist", "listaBazDanych"])
         XCTAssertEqual(byPath["dblist"]?.type, "string")
         XCTAssertNotNil(byPath["dblist"]?.description)
-        // Something not in any required list stays optional.
+
+        // Something in no required list at all stays optional.
         XCTAssertEqual(byPath["replicaCount"]?.isRequired, false)
+        XCTAssertEqual(byPath["replicaCount"]?.oneOfAlternatives, [])
+    }
+
+    /// `image` already has `image.tag` and friends from values.yaml. Adding a
+    /// second, empty YAML box for the parent object asks the user to retype
+    /// what is already on screen.
+    func testObjectsAlreadyExpandedInTheFormAreNotAddedAgain() throws {
+        let fields = try ChartValues.fields(from: "image:\n  tag: \"1.0\"\n  product: standard\n")
+        let merged = ChartValues.merge(fields: fields, schema: ChartSchema.properties(fromSchema: try schemaFixture()))
+
+        XCTAssertFalse(merged.contains { $0.path == "image" })
+        XCTAssertTrue(merged.contains { $0.path == "image.tag" })
+        // The keys that genuinely have nowhere else to appear still do.
+        XCTAssertTrue(merged.contains { $0.path == "dblist" })
     }
 
     func testResolvesLocalRefsAndMixedTypeOneOf() throws {
@@ -48,6 +68,7 @@ final class ChartSchemaTests: XCTestCase {
         XCTAssertEqual(byPath["cpu"]?.type, "string")
         XCTAssertEqual(byPath["cpu"]?.description, "A Kubernetes quantity.")
         XCTAssertEqual(byPath["cpu"]?.isRequired, true)
+        XCTAssertEqual(byPath["cpu"]?.oneOfAlternatives, [])
         XCTAssertEqual(byPath["mode"]?.enumValues, ["fast", "slow"])
     }
 
@@ -90,7 +111,7 @@ final class ChartSchemaTests: XCTestCase {
         let byPath = Dictionary(merged.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
 
         let dblist = try XCTUnwrap(byPath["dblist"], "dblist musi trafić do formularza ze schematu")
-        XCTAssertTrue(dblist.isRequired)
+        XCTAssertEqual(dblist.oneOfAlternatives, ["dblist", "listaBazDanych"])
         XCTAssertEqual(dblist.kind, .string)
         XCTAssertEqual(dblist.defaultValue, "")
         XCTAssertNotNil(dblist.comment)

--- a/ContainerGUITests/ChartSchemaTests.swift
+++ b/ContainerGUITests/ChartSchemaTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+/// A chart's `values.schema.json` can require keys that `values.yaml` never
+/// defaults. The form is generated from values.yaml, so without reading the
+/// schema those keys simply have no field — and the install fails validation
+/// with nowhere to fix it. Fixture captured from the real `soneta/soneta` chart.
+final class ChartSchemaTests: XCTestCase {
+    private func schemaFixture() throws -> Data {
+        let bundle = Bundle(for: type(of: self))
+        let url = bundle.url(forResource: "soneta-values.schema", withExtension: "json", subdirectory: "Fixtures")
+            ?? bundle.url(forResource: "soneta-values.schema", withExtension: "json")
+        return try Data(contentsOf: try XCTUnwrap(url, "Brak fixtury schematu"))
+    }
+
+    func testFindsKeysRequiredThroughOneOfBranches() throws {
+        let properties = ChartSchema.properties(fromSchema: try schemaFixture())
+        let byPath = Dictionary(properties.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
+
+        // The chart spells "either dblist or listaBazDanych" as a top-level
+        // oneOf; both must surface or the user cannot satisfy either branch.
+        XCTAssertEqual(byPath["dblist"]?.isRequired, true)
+        XCTAssertEqual(byPath["listaBazDanych"]?.isRequired, true)
+        XCTAssertEqual(byPath["image"]?.isRequired, true)
+        XCTAssertEqual(byPath["dblist"]?.type, "string")
+        XCTAssertNotNil(byPath["dblist"]?.description)
+        // Something not in any required list stays optional.
+        XCTAssertEqual(byPath["replicaCount"]?.isRequired, false)
+    }
+
+    func testResolvesLocalRefsAndMixedTypeOneOf() throws {
+        let schema = """
+        {
+          "$defs": {
+            "Quantity": { "oneOf": [{"type": "string"}, {"type": "number"}],
+                          "description": "A Kubernetes quantity." }
+          },
+          "type": "object",
+          "required": ["cpu"],
+          "properties": {
+            "cpu": { "$ref": "#/$defs/Quantity" },
+            "mode": { "type": "string", "enum": ["fast", "slow"] }
+          }
+        }
+        """
+        let properties = ChartSchema.properties(fromSchema: Data(schema.utf8))
+        let byPath = Dictionary(uniqueKeysWithValues: properties.map { ($0.path, $0) })
+
+        XCTAssertEqual(byPath["cpu"]?.type, "string")
+        XCTAssertEqual(byPath["cpu"]?.description, "A Kubernetes quantity.")
+        XCTAssertEqual(byPath["cpu"]?.isRequired, true)
+        XCTAssertEqual(byPath["mode"]?.enumValues, ["fast", "slow"])
+    }
+
+    func testWalksNestedObjectProperties() throws {
+        let schema = """
+        {
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "object",
+              "required": ["tag"],
+              "properties": {
+                "tag": { "type": "string" },
+                "pullPolicy": { "type": "string" }
+              }
+            }
+          }
+        }
+        """
+        let byPath = Dictionary(
+            uniqueKeysWithValues: ChartSchema.properties(fromSchema: Data(schema.utf8)).map { ($0.path, $0) }
+        )
+
+        XCTAssertEqual(byPath["image.tag"]?.isRequired, true)
+        XCTAssertEqual(byPath["image.pullPolicy"]?.isRequired, false)
+    }
+
+    func testMalformedSchemaDegradesToNoProperties() {
+        XCTAssertTrue(ChartSchema.properties(fromSchema: Data("not json".utf8)).isEmpty)
+        XCTAssertTrue(ChartSchema.properties(fromSchema: Data("{}".utf8)).isEmpty)
+    }
+
+    // MARK: - Merging into the values.yaml-derived form
+
+    func testUndefaultedRequiredKeysAreAppendedToTheForm() throws {
+        let fields = try ChartValues.fields(from: "replicaCount: 1\nimage:\n  tag: \"1.0\"\n")
+        XCTAssertFalse(fields.contains { $0.path == "dblist" })
+
+        let merged = ChartValues.merge(fields: fields, schema: ChartSchema.properties(fromSchema: try schemaFixture()))
+        let byPath = Dictionary(merged.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
+
+        let dblist = try XCTUnwrap(byPath["dblist"], "dblist musi trafić do formularza ze schematu")
+        XCTAssertTrue(dblist.isRequired)
+        XCTAssertEqual(dblist.kind, .string)
+        XCTAssertEqual(dblist.defaultValue, "")
+        XCTAssertNotNil(dblist.comment)
+    }
+
+    func testMergeKeepsValuesYAMLDefaultsAndAnnotatesThem() throws {
+        let fields = try ChartValues.fields(from: "replicaCount: 1\n")
+        let merged = ChartValues.merge(fields: fields, schema: ChartSchema.properties(fromSchema: try schemaFixture()))
+        let replicaCount = try XCTUnwrap(merged.first { $0.path == "replicaCount" })
+
+        // The default from values.yaml wins; the schema only annotates.
+        XCTAssertEqual(replicaCount.defaultValue, "1")
+        XCTAssertEqual(replicaCount.kind, .number)
+        XCTAssertFalse(replicaCount.isRequired)
+    }
+
+    func testMergeWithoutASchemaChangesNothing() throws {
+        let fields = try ChartValues.fields(from: "replicaCount: 1\n")
+        XCTAssertEqual(ChartValues.merge(fields: fields, schema: []).map(\.path), fields.map(\.path))
+    }
+
+    /// Required keys are what block the install, so they must not be buried at
+    /// the bottom of a 128-line form.
+    func testRequiredAdditionsSortAheadOfOptionalOnes() throws {
+        let merged = ChartValues.merge(
+            fields: [],
+            schema: ChartSchema.properties(fromSchema: try schemaFixture())
+        )
+        let addedPaths = merged.map(\.path)
+        let dblistIndex = try XCTUnwrap(addedPaths.firstIndex(of: "dblist"))
+        let optionalIndex = try XCTUnwrap(addedPaths.firstIndex(of: "replicaCount"))
+        XCTAssertLessThan(dblistIndex, optionalIndex)
+    }
+}

--- a/ContainerGUITests/ChartValuesTests.swift
+++ b/ContainerGUITests/ChartValuesTests.swift
@@ -24,7 +24,7 @@ final class ChartValuesTests: XCTestCase {
         XCTAssertEqual(byPath["replicaCount"]?.kind, .number)
         XCTAssertEqual(byPath["adminMode"]?.kind, .boolean)
         XCTAssertEqual(byPath["image.tag"]?.kind, .string)
-        XCTAssertEqual(byPath["imagePullSecrets"]?.kind, .complex)
+        XCTAssertEqual(byPath["imagePullSecrets"]?.kind, .stringList)
         XCTAssertEqual(byPath["image.product"]?.defaultValue, "standard")
         XCTAssertEqual(byPath["image.tag"]?.group, "image")
         XCTAssertEqual(byPath["image.tag"]?.label, "tag")
@@ -115,6 +115,89 @@ final class ChartValuesTests: XCTestCase {
         )
         let loaded = try XCTUnwrap(Yams.load(yaml: overrides) as? [String: Any])
         XCTAssertEqual(loaded.keys.sorted(), ["web"])
+    }
+
+    // MARK: - Scalar lists
+
+    /// Charts are full of `key: []`. Adding one entry to an empty list is the
+    /// most common edit there is, so it gets a row editor rather than a
+    /// text field where the user types YAML punctuation.
+    func testScalarListsGetARowEditorAndObjectListsDoNot() throws {
+        let yaml = """
+        imagePullSecrets: []
+        args:
+          - --verbose
+          - --port=8080
+        volumes:
+          - name: data
+            mountPath: /data
+        resources: {}
+        """
+        let byPath = Dictionary(uniqueKeysWithValues: try ChartValues.fields(from: yaml).map { ($0.path, $0) })
+
+        XCTAssertEqual(byPath["imagePullSecrets"]?.kind, .stringList)
+        XCTAssertEqual(byPath["args"]?.kind, .stringList)
+        // A list of objects cannot be rows of text fields.
+        XCTAssertEqual(byPath["volumes"]?.kind, .yaml)
+        XCTAssertEqual(byPath["resources"]?.kind, .yaml)
+    }
+
+    func testScalarListDefaultsRenderInFlowStyle() throws {
+        let yaml = """
+        args:
+          - --verbose
+          - --port=8080
+        empty: []
+        """
+        let byPath = Dictionary(uniqueKeysWithValues: try ChartValues.fields(from: yaml).map { ($0.path, $0) })
+
+        // Flow style keeps the stored edit a single line, so the form and the
+        // YAML tab do not reformat it on every switch.
+        XCTAssertEqual(byPath["args"]?.defaultValue, #"["--verbose", "--port=8080"]"#)
+        XCTAssertEqual(byPath["empty"]?.defaultValue, "[]")
+    }
+
+    func testListItemsParsesBothFlowAndBlockStyle() {
+        XCTAssertEqual(ChartValues.listItems(#"["a", "b"]"#), ["a", "b"])
+        XCTAssertEqual(ChartValues.listItems("- a\n- b"), ["a", "b"])
+        XCTAssertEqual(ChartValues.listItems("[]"), [])
+        XCTAssertEqual(ChartValues.listItems(""), [])
+        XCTAssertEqual(ChartValues.listItems("nonsense: {"), [])
+    }
+
+    func testEditedListStaysAListInTheOverrides() throws {
+        let fields = try ChartValues.fields(from: "imagePullSecrets: []\n")
+        let yaml = try ChartValues.overridesYAML(
+            edits: ["imagePullSecrets": ChartValues.flowList(["regcred", "ghcr"])],
+            fields: fields
+        )
+
+        let loaded = try XCTUnwrap(Yams.load(yaml: yaml) as? [String: Any])
+        XCTAssertEqual(loaded["imagePullSecrets"] as? [String], ["regcred", "ghcr"])
+    }
+
+    /// Emptying a list must yield `[]`, not `null` — a chart's
+    /// `range .Values.args` fails on null but iterates nothing on an empty list.
+    func testEmptiedListStaysAnEmptyListNotNull() throws {
+        let fields = try ChartValues.fields(from: "args:\n  - --verbose\n")
+        let yaml = try ChartValues.overridesYAML(
+            edits: ["args": ChartValues.flowList([])],
+            fields: fields
+        )
+
+        let loaded = try XCTUnwrap(Yams.load(yaml: yaml) as? [String: Any])
+        XCTAssertNotNil(loaded["args"] as? [Any])
+        XCTAssertEqual((loaded["args"] as? [Any])?.count, 0)
+    }
+
+    func testListEditsRoundTripThroughTheYAMLTab() throws {
+        let fields = try ChartValues.fields(from: "imagePullSecrets: []\nreplicaCount: 1\n")
+        let edits = ["imagePullSecrets": ChartValues.flowList(["regcred"])]
+
+        let yaml = try ChartValues.overridesYAML(edits: edits, fields: fields)
+        let recovered = ChartValues.edits(fromOverrides: yaml, fields: fields)
+
+        XCTAssertEqual(ChartValues.listItems(recovered["imagePullSecrets"] ?? ""), ["regcred"])
     }
 
     func testEmptyChartValuesYieldNoFields() throws {

--- a/Fixtures/soneta-values.schema.json
+++ b/Fixtures/soneta-values.schema.json
@@ -1,0 +1,507 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$defs": {
+        "Quantity": {
+            "oneOf": [
+                { "type": "string" },
+                { "type": "number" }
+            ],
+            "description": "A Kubernetes resource quantity, e.g. '100m', '1Gi', '42'."
+        },
+        "ResourceList": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#/$defs/Quantity" },
+            "description": "A map of resource names to quantities."
+        },
+        "resourceRequirements": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "$ref": "#/$defs/ResourceList",
+                    "description": "Maximum amount of compute resources allowed."
+                },
+                "requests": {
+                    "$ref": "#/$defs/ResourceList",
+                    "description": "Minimum amount of compute resources required."
+                }
+            },
+            "description": "Describes the compute resource requirements."
+        },
+        "pvcSpec": {
+            "type": "object",
+            "properties": {
+                "accessModes": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "List of access modes for the PVC (e.g. ReadWriteOnce, ReadOnlyMany, ReadWriteMany)"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "storage": { 
+                                    "$ref": "#/$defs/Quantity", 
+                                    "description": "Requested storage size (e.g. 10Mi, 1Gi)" }
+                            },
+                            "required": ["storage"]
+                        }
+                    },
+                    "required": ["requests"]
+                },
+                "storageClassName": {
+                    "type": "string",
+                    "description": "Name of the StorageClass to use"
+                },
+                "selector": {
+                    "type": "object",
+                    "properties": {
+                        "matchLabels": {
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                        },
+                        "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "key": { "type": "string" },
+                                    "operator": { "type": "string" },
+                                    "values": {
+                                        "type": "array",
+                                        "items": { "type": "string" }
+                                    }
+                                },
+                                "required": ["key", "operator"]
+                            }
+                        }
+                    }
+                },
+                "volumeMode": {
+                    "type": "string",
+                    "enum": ["Filesystem", "Block"],
+                    "description": "Defines whether the volume is a filesystem or block device"
+                },
+                "dataSource": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "kind": { "type": "string" },
+                        "apiGroup": { "type": "string" }
+                    },
+                    "required": ["name", "kind"]
+                },
+                "dataSourceRef": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "kind": { "type": "string" },
+                        "apiGroup": { "type": "string" }
+                    },
+                    "required": ["name", "kind"]
+                },
+                "volumeName": {
+                    "type": "string",
+                    "description": "Bind to a specific PersistentVolume by name"
+                }
+            },
+            "required": ["accessModes", "resources"]
+        }
+    },
+    "type": "object",
+    "title": "Values",
+    "oneOf": [ 
+        { "required": ["image", "dblist"] },
+        { "required": ["image", "listaBazDanych"] }
+    ],
+    "properties": {
+        "image": {
+            "type": "object",
+            "description": "Container image configuration, including repository, tag, product type, and postfixes for different components. Allows you to specify which components should be enabled (e.g., webapi, scheduler, webwcf). Example: product: 'standard', tag: '2504.2.4', webTagPostfix: -alpine, serverTagPostfix: -alpine, repository: ''",
+            "properties": {
+                "repository": {
+                    "type" :"string",
+                    "default": "",
+                    "description": "Repository url, if empty then dockerhub"
+                },
+                "product": {
+                    "type" :"string",
+                    "default": "standard",
+                    "description": "Product type, used to determine the image name",
+                    "enum": ["standard", "premium"]
+                },
+                "tag":{
+                    "type": "string"
+                },
+                "scheduler": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "webapi": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "webwcf": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "webTagpostfix": {
+                    "type": "string",
+                    "default": "",
+                    "enum": ["-alpine", "-windowsservercore"]
+                },
+                "serverTagpostfix": {
+                    "type": "string",
+                    "default": "",
+                    "enum": ["-alpine", "-windowsservercore"]
+                }
+            }
+        },
+        "dblist": {
+            "type": "string",
+            "description": "XML string containing database connection definitions. Used by the business logic to provide a list of databases. Example: <DatabaseCollection><MsSqlDatabase>...</MsSqlDatabase></DatabaseCollection>"
+        },
+        "listaBazDanych": {
+            "type": "string",
+            "description": "[DEPRECATED] Use 'dblist' instead. This property is obsolete and will be removed in a future release.",
+            "deprecated": true
+        },
+        "replicaCount": {
+            "type": "number",
+            "description": "Number of replicas for the main container (e.g., web)."
+        },
+
+        "imagePullSecrets": {
+            "type": "array",
+            "description": "List of Kubernetes secrets used to pull images from private registries."
+        },
+
+        "nameOverride": {
+            "type": "string",
+            "description": "Overrides the default Helm release name for resources."
+        },
+
+        "fullnameOverride": {
+            "type": "string",
+            "description": "Overrides the full Helm release name for resources."
+        },
+        "adminMode": {
+            "type": "boolean",
+            "description": "Enables the application's admin mode."
+        },
+        "appsettings": {
+            "type": "object",
+            "description": "Object with application settings passed to ConfigMap. Allows you to provide configuration such as orchestrator.kubernetes, RoutingMethod, Logging, Telemetry, HealthCheck, etc. Example: { 'orchestrator': { 'kubernetes': { ... } }, 'RoutingMethod': 'CommHub', ... }",
+            "additionalProperties": true
+        },
+        "service": {
+            "type": "object",
+            "description": "Kubernetes Service configuration for individual components, e.g., service type (NodePort, ClusterIP).",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "server": {
+                    "type": "object",
+                    "description": "Configuration for the server in the service",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+
+        "ingress": {
+            "type": "object",
+            "description": "Ingress resource configuration, including host, class, TLS, and annotations. Allows exposing the application outside the cluster.",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "host": {
+                    "type": "string",
+                    "description": "The host address for the ingress"
+                }
+            }
+        },
+
+        "nodeSelector": {
+            "type": "array",
+            "description": "List of Kubernetes node selectors on which pods should be scheduled."
+        },
+
+        "tolerations": {
+            "type": "array",
+            "description": "List of pod tolerations, allowing scheduling on nodes with specific taints."
+        },
+
+        "affinity": {
+            "type": "object",
+            "description": "Pod affinity rules, e.g., colocation preferences."
+        },
+
+        "resources": {
+            "type": "object",
+            "description": "Resource configuration (CPU, RAM) for individual components and PVC definition. Example: web: { limits: { cpu: '200m', memory: '256Mi' }, requests: { cpu: '50m', memory: '128Mi' } }, pvc: { spec: { ... } }",
+            "properties": {
+                "web": { "$ref": "#/$defs/resourceRequirements" },
+                "webapi": { "$ref": "#/$defs/resourceRequirements" },
+                "server": { "$ref": "#/$defs/resourceRequirements" },
+                "scheduler": { "$ref": "#/$defs/resourceRequirements" },
+                "orchestrator": { "$ref": "#/$defs/resourceRequirements" },
+                "router": { "$ref": "#/$defs/resourceRequirements" },
+                "commhub": { "$ref": "#/$defs/resourceRequirements" },
+                "webwcf": { "$ref": "#/$defs/resourceRequirements" },
+                "admin": { "$ref": "#/$defs/resourceRequirements" },
+                "pvc": {
+                    "type": "object",
+                    "description": "PersistentVolumeClaim configuration for the chart",
+                    "properties": {
+                        "spec": {
+                            "$ref": "#/$defs/pvcSpec"
+                        }
+                    }
+                }
+            }
+        },
+
+        "volumes": {
+            "type": "object",
+            "description": "Volume definitions mounted to pods. Allows mounting host directories or other volume types to selected components (e.g., backend, frontend, web, webapi). Each entry contains a name, mount path, and volume specification. Example: { all: [ { name: 'dotmemory', mountPath: '/dotmemory', spec: { hostPath: { path: '/run/desktop/mnt/host/c/...', type: 'Directory' } } } ] }",
+            "properties": {
+                "all": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                },
+                "frontend:": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                },
+                "backend": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                },
+                "web": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                },
+                "webapi": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                },
+                "webwcf": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                },
+                "server": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                },
+                "scheduler": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "spec": {
+                            "type":"object",
+                            "description": "Kubernetes volume specification"
+                        }
+                    }
+                }
+            }  
+        },
+
+        "envs": {
+            "type": "object",
+            "description": "Set of environment variables passed to pods, divided by component. Example: { all: [ { name: 'DOTNET_USE_POLLING_FILE_WATCHER', value: '1' } ] }",
+            "properties": {
+                "all": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "frontend:": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "backend": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "web": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "webapi": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "webwcf": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "server": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "scheduler": {
+                    "type": "array",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+
+        "args": {
+            "type": "object",
+            "description": "Startup arguments passed to containers of individual components. Example: { web: ['--urls', 'http://*:8080'] }",
+            "properties": {
+                "frontend": { "type": "array", "items": {"type": "string"} },
+                "web": { "type": "array", "items": {"type": "string"} },
+                "webapi": { "type": "array", "items": {"type": "string"} },
+                "webwcf": { "type": "array", "items": {"type": "string"} },
+                "backend": { "type": "array", "items": {"type": "string"} },
+                "server": { "type": "array", "items": {"type": "string"} },
+                "scheduler": { "type": "array", "items": {"type": "string"} }
+            }
+        } 
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -143,6 +143,7 @@ targets:
       - path: ContainerGUI/CLI/BinaryResolver.swift
       - path: ContainerGUI/Features/Containers/LogTailLimit.swift
       - path: ContainerGUI/Features/Helm/ChartValues.swift
+      - path: ContainerGUI/Features/Helm/ChartSchema.swift
       - path: ContainerGUI/Widget/WidgetSnapshot.swift
       - path: ContainerGUI/Terminal/TerminalEngine.swift
       - path: ContainerGUI/Compose


### PR DESCRIPTION
Follow-up on the cards/widget branch, all from actually using the wizard against the real `soneta/soneta` chart.

## Values editor

- **The requirement badge was lying.** The chart needs `image` **and** either `dblist` or `listaBazDanych` — a top-level `oneOf`. All three were badged a flat "wymagane". Requirements are now split: keys common to every branch stay required, the competing ones get a "jedno z" badge and a tip naming the alternatives.
- **`image` showed up as an empty YAML box.** Its children already come from `values.yaml`; the schema's parent object was added on top, asking the user to retype what was on screen. Object properties whose children the form already lists are skipped.
- **One line is useless for an XML database list.** String fields expand into a real text box — automatically when the value has line breaks, runs past 60 characters, or is a required key the chart never defaults; on demand otherwise. An expanded field takes the full width of the pane rather than the inline slot.
- **Flipping a switch moved every control.** The reset button appeared only once a field was edited; it now holds its slot whether visible or not.
- **Lists are lists.** Charts are full of `imagePullSecrets: []`, `args: []`, `envs.<component>: []`; scalar lists get a row editor with add/remove, lists of objects and maps get a multi-line YAML box. Emptying a list yields `[]`, not `null` — `range .Values.args` fails on null but iterates nothing on an empty list.
- **Values can come from a file.** Per-field for strings and YAML blocks, and one for a whole overrides file (the `-f my-values.yaml` workflow, without leaving the wizard).

## Schema awareness

Charts can require keys they never default — `dblist` appears nowhere in `values.yaml`, so a form generated from defaults alone could never offer it and the install failed validation with nothing to fix. `values.schema.json` is now read too (helm has no `show schema`, so the chart is unpacked once and cached per chart+version), contributing missing keys, descriptions, enums and required markers.

**It does not block the form.** That unpack is a download, so it happens behind an already-usable form with a small status; the extra fields drop in when it lands, and a version switch mid-flight is discarded rather than merged into the wrong chart.

## Elsewhere

- **Charts can be browsed, not just searched** — a repository picker lists everything in a repo, with the text field demoted to a filter within it.
- **Clicking a cluster does something**: a detail pane with facts, nodes, the Helm releases actually deployed there, and copy-pasteable kubectl/helm commands already carrying the app-managed kubeconfig.
- **Container search** over id, image, Compose project/service and IP.
- **Running containers sort to the top**, projects with something running above idle ones; alphabetical within each half so nothing jumps as usage fluctuates.
- **The meters stopped drifting** — the caption sized itself, so a card reflowed when CPU went from "0%" to "100%". Fixed right-aligned slot now.
- Cards are tighter throughout.

## Checks

- `xcodebuild test` — **123 tests, 0 failures** (16 new across list handling and schema parsing, against a fixture captured from the real soneta chart).
- Localization en/pl/zh-Hans at **554 keys each**, key sets verified identical, `plutil -lint` clean.

## Known limitation

Which string fields open expanded is a heuristic — line breaks, length, and "required but undefaulted". This schema offers no `maxLength`, `examples` or `contentMediaType` to do better with; on a chart that does provide them, honoring those would beat the guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLBQAYwfcPxpmXaNmQBezg