### PR TITLE
0.6.0: publish the signed appcast entry

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>ContainerGUI</title>
         <item>
-            <title>0.5.0</title>
-            <pubDate>Sat, 08 Aug 2026 18:46:09 +0200</pubDate>
-            <sparkle:version>7</sparkle:version>
-            <sparkle:shortVersionString>0.5.0</sparkle:shortVersionString>
+            <title>0.6.0</title>
+            <pubDate>Thu, 27 Aug 2026 10:29:41 +0200</pubDate>
+            <sparkle:version>8</sparkle:version>
+            <sparkle:shortVersionString>0.6.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/sembsa/ContainerDesktop/releases/latest/download/ContainerDesktop.dmg" length="19756885" type="application/octet-stream" sparkle:edSignature="GEr4hBjLkvxz1ZkytgROa5+nk+9xeNza6zgz5bpXCNGZhvvsaoTWk2HVxQUBHPdx3QyFaK2izDDMMzNQhWQlCA=="/>
+            <enclosure url="https://github.com/sembsa/ContainerDesktop/releases/latest/download/ContainerDesktop.dmg" length="21005572" type="application/octet-stream" sparkle:edSignature="JIK/mzHQPf/DnooHaXuLKMPK9VJHXeUnGkvGfpOUPozB7UeLkIIvlibEfvG0iWVIzoYMS4d6hCiMpT52V3Y/BA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Sparkle feed entry for 0.6.0 (build 8). The GitHub release and its DMG are already published, so `releases/latest/download` resolves to the asset this signature was made for.